### PR TITLE
Fix/notification and group bugs

### DIFF
--- a/Domain/.swiftpm/xcode/xcuserdata/yong.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Domain/.swiftpm/xcode/xcuserdata/yong.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Domain.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>3</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Domain/.swiftpm/xcode/xcuserdata/yong.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Domain/.swiftpm/xcode/xcuserdata/yong.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Domain.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>2</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Domain/Sources/Domain/Repositories/UserRepositoryProtocol.swift
+++ b/Domain/Sources/Domain/Repositories/UserRepositoryProtocol.swift
@@ -15,6 +15,27 @@ public protocol UserRepositoryInterface: Sendable {
     func registerDeviceToken(token: String) async throws
     /// 광고 시청 보상으로 하트를 지급하고 남은 하트 수를 반환합니다.
     func grantAdHearts(amount: Int) async throws -> Int
+    func getNotificationPreferences() async throws -> NotificationPreferences
+    func updateNotificationPreferences(_ params: [String: Any]) async throws -> NotificationPreferences
+}
+
+public struct NotificationPreferences: Equatable, Sendable {
+    public let notifAnswer: Bool
+    public let notifNudge: Bool
+    public let notifQuestion: Bool
+    public let quietHoursEnabled: Bool
+    public let quietHoursStart: String
+    public let quietHoursEnd: String
+
+    public init(notifAnswer: Bool, notifNudge: Bool, notifQuestion: Bool,
+                quietHoursEnabled: Bool, quietHoursStart: String, quietHoursEnd: String) {
+        self.notifAnswer = notifAnswer
+        self.notifNudge = notifNudge
+        self.notifQuestion = notifQuestion
+        self.quietHoursEnabled = quietHoursEnabled
+        self.quietHoursStart = quietHoursStart
+        self.quietHoursEnd = quietHoursEnd
+    }
 }
 
 public enum UserError: Error, Equatable, Sendable {

--- a/Mongle.xcodeproj/project.pbxproj
+++ b/Mongle.xcodeproj/project.pbxproj
@@ -314,7 +314,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yongheon.Mongle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -348,7 +348,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yongheon.Mongle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Mongle.xcodeproj/project.pbxproj
+++ b/Mongle.xcodeproj/project.pbxproj
@@ -314,7 +314,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yongheon.Mongle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -348,7 +348,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.3;
+				MARKETING_VERSION = 1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yongheon.Mongle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/MongleData/Sources/MongleData/DataSources/Remote/API/APIEndpoint.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/API/APIEndpoint.swift
@@ -198,6 +198,8 @@ enum UserEndpoint: APIEndpoint {
     case getMyStreak
     case registerDeviceToken(token: String)
     case adHeartReward(amount: Int)
+    case getNotificationPreferences
+    case updateNotificationPreferences(params: [String: Any])
 
     var path: String {
         switch self {
@@ -213,16 +215,18 @@ enum UserEndpoint: APIEndpoint {
             return "/users/me/device-token"
         case .adHeartReward:
             return "/users/me/hearts/ad-reward"
+        case .getNotificationPreferences, .updateNotificationPreferences:
+            return "/users/me/notification-preferences"
         }
     }
 
     var method: HTTPMethod {
         switch self {
-        case .fetchUser, .getMyStreak:
+        case .fetchUser, .getMyStreak, .getNotificationPreferences:
             return .get
         case .updateUser, .updateMe:
             return .put
-        case .registerDeviceToken:
+        case .registerDeviceToken, .updateNotificationPreferences:
             return .patch
         case .adHeartReward:
             return .post
@@ -243,6 +247,8 @@ enum UserEndpoint: APIEndpoint {
             return try? JSONEncoder().encode(["name": name])
         case .adHeartReward(let amount):
             return try? JSONSerialization.data(withJSONObject: ["amount": amount])
+        case .updateNotificationPreferences(let params):
+            return try? JSONSerialization.data(withJSONObject: params)
         default:
             return nil
         }

--- a/MongleData/Sources/MongleData/Mappers/FamilyMapper.swift
+++ b/MongleData/Sources/MongleData/Mappers/FamilyMapper.swift
@@ -18,7 +18,7 @@ struct FamilyMapper {
             name: dto.name,
             memberIds: members.map { $0.id },
             createdBy: UUID(uuidString: dto.createdById) ?? UUID(),
-            createdAt: ISO8601DateFormatter().date(from: dto.createdAt) ?? Date(),
+            createdAt: parseISO8601(dto.createdAt),
             inviteCode: dto.inviteCode,
             memberMoodIds: dto.members.map { $0.moodId ?? "loved" },
             streakDays: dto.streakDays ?? 0
@@ -33,7 +33,7 @@ struct FamilyMapper {
             name: dto.name,
             memberIds: dto.memberIds.compactMap { UUID(uuidString: $0) },
             createdBy: UUID(uuidString: dto.createdBy) ?? UUID(),
-            createdAt: ISO8601DateFormatter().date(from: dto.createdAt) ?? Date(),
+            createdAt: parseISO8601(dto.createdAt),
             inviteCode: dto.inviteCode
         )
     }

--- a/MongleData/Sources/MongleData/Mappers/ISO8601Parser.swift
+++ b/MongleData/Sources/MongleData/Mappers/ISO8601Parser.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// 서버 ISO 8601 날짜 문자열 파싱 (밀리초 포함/미포함 모두 지원)
+/// 서버(Prisma)는 "2026-04-13T12:00:00.000Z" (밀리초 포함) 형식을 반환함.
+/// ISO8601DateFormatter 기본 설정은 밀리초를 지원하지 않아 파싱 실패 → Date()로 폴백되는 버그 방지.
+func parseISO8601(_ string: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    // 밀리초 포함 형식 먼저 시도
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = formatter.date(from: string) { return date }
+    // 밀리초 미포함 형식 폴백
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter.date(from: string) ?? Date()
+}

--- a/MongleData/Sources/MongleData/Mappers/MemberMapper.swift
+++ b/MongleData/Sources/MongleData/Mappers/MemberMapper.swift
@@ -17,7 +17,7 @@ struct MemberMapper {
             userId: UUID(uuidString: dto.userId) ?? UUID(),
             familyId: UUID(uuidString: dto.familyId) ?? UUID(),
             role: FamilyRole(rawValue: dto.role) ?? .other,
-            joinedAt: ISO8601DateFormatter().date(from: dto.joinedAt) ?? Date(),
+            joinedAt: parseISO8601(dto.joinedAt),
             isActive: dto.isActive
         )
     }

--- a/MongleData/Sources/MongleData/Mappers/QuestionMapper.swift
+++ b/MongleData/Sources/MongleData/Mappers/QuestionMapper.swift
@@ -27,7 +27,7 @@ struct QuestionMapper {
             content: q.content,
             category: category,
             order: 0,
-            createdAt: ISO8601DateFormatter().date(from: q.createdAt) ?? Date(),
+            createdAt: parseISO8601(q.createdAt),
             dailyQuestionId: dto.id,
             familyAnswerCount: dto.familyAnswerCount,
             hasMyAnswer: dto.hasMyAnswer,
@@ -43,7 +43,7 @@ struct QuestionMapper {
             content: dto.content,
             category: QuestionCategory(rawValue: dto.category) ?? .daily,
             order: dto.order,
-            createdAt: ISO8601DateFormatter().date(from: dto.createdAt) ?? Date()
+            createdAt: parseISO8601(dto.createdAt)
         )
     }
 

--- a/MongleData/Sources/MongleData/Mappers/UserMapper.swift
+++ b/MongleData/Sources/MongleData/Mappers/UserMapper.swift
@@ -20,7 +20,7 @@ struct UserMapper {
             role: familyRole(from: dto.role),
             hearts: dto.hearts ?? 0,
             moodId: dto.moodId ?? "loved",
-            createdAt: ISO8601DateFormatter().date(from: dto.createdAt) ?? Date()
+            createdAt: parseISO8601(dto.createdAt)
         )
     }
 

--- a/MongleData/Sources/MongleData/Repositories/UserRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/UserRepository.swift
@@ -49,4 +49,34 @@ final class UserRepository: UserRepositoryInterface {
         let response: Response = try await apiClient.request(UserEndpoint.adHeartReward(amount: amount))
         return response.heartsRemaining
     }
+
+    func getNotificationPreferences() async throws -> NotificationPreferences {
+        let dto: NotificationPreferencesDTO = try await apiClient.request(UserEndpoint.getNotificationPreferences)
+        return dto.toDomain()
+    }
+
+    func updateNotificationPreferences(_ params: [String: Any]) async throws -> NotificationPreferences {
+        let dto: NotificationPreferencesDTO = try await apiClient.request(UserEndpoint.updateNotificationPreferences(params: params))
+        return dto.toDomain()
+    }
+}
+
+struct NotificationPreferencesDTO: Decodable {
+    let notifAnswer: Bool
+    let notifNudge: Bool
+    let notifQuestion: Bool
+    let quietHoursEnabled: Bool
+    let quietHoursStart: String
+    let quietHoursEnd: String
+
+    func toDomain() -> NotificationPreferences {
+        NotificationPreferences(
+            notifAnswer: notifAnswer,
+            notifNudge: notifNudge,
+            notifQuestion: notifQuestion,
+            quietHoursEnabled: quietHoursEnabled,
+            quietHoursStart: quietHoursStart,
+            quietHoursEnd: quietHoursEnd
+        )
+    }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/NotificationSettingsFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/NotificationSettingsFeature.swift
@@ -1,5 +1,8 @@
 import Foundation
+import UIKit
+import UserNotifications
 import ComposableArchitecture
+import Domain
 
 @Reducer
 public struct NotificationSettingsFeature {
@@ -22,6 +25,9 @@ public struct NotificationSettingsFeature {
         public var notificationItems: [ToggleItem]
         public var quietHours: String
         public var quietHoursEnabled: Bool
+        public var isLoading: Bool = true
+        /// 시스템 알림이 차단된 상태인지 (배너 표시용)
+        public var isSystemNotificationDenied: Bool = false
 
         public init() {
             let ud = UserDefaults.standard
@@ -39,9 +45,16 @@ public struct NotificationSettingsFeature {
     }
 
     public enum Action: Sendable, Equatable {
+        case onAppear
+        case scenePhaseActive
+        case systemPermissionChecked(isDenied: Bool)
+        case preferencesLoaded(NotificationPreferences)
+        case loadFailed
         case closeTapped
         case toggleChanged(String, Bool)
         case quietHoursToggleChanged(Bool)
+        case openSystemSettingsTapped
+        case serverUpdateCompleted
         case delegate(Delegate)
 
         public enum Delegate: Sendable, Equatable {
@@ -49,11 +62,59 @@ public struct NotificationSettingsFeature {
         }
     }
 
+    @Dependency(\.userRepository) var userRepository
+
     public init() {}
 
     public var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
+            case .onAppear, .scenePhaseActive:
+                let isInitialLoad = state.isLoading
+                if action == .onAppear { state.isLoading = true }
+                return .run { send in
+                    // 시스템 알림 권한 상태 체크
+                    let settings = await UNUserNotificationCenter.current().notificationSettings()
+                    let isDenied = settings.authorizationStatus == .denied
+                    await send(.systemPermissionChecked(isDenied: isDenied))
+
+                    // 최초 로드 시에만 서버 선호도 가져오기
+                    if isInitialLoad {
+                        do {
+                            let prefs = try await userRepository.getNotificationPreferences()
+                            await send(.preferencesLoaded(prefs))
+                        } catch {
+                            await send(.loadFailed)
+                        }
+                    }
+                }
+
+            case .systemPermissionChecked(let isDenied):
+                state.isSystemNotificationDenied = isDenied
+                return .none
+
+            case .preferencesLoaded(let prefs):
+                state.isLoading = false
+                if let idx = state.notificationItems.firstIndex(where: { $0.id == "r1" }) {
+                    state.notificationItems[idx].isOn = prefs.notifAnswer
+                }
+                if let idx = state.notificationItems.firstIndex(where: { $0.id == "r3" }) {
+                    state.notificationItems[idx].isOn = prefs.notifNudge
+                }
+                if let idx = state.notificationItems.firstIndex(where: { $0.id == "r5" }) {
+                    state.notificationItems[idx].isOn = prefs.notifQuestion
+                }
+                state.quietHoursEnabled = prefs.quietHoursEnabled
+                UserDefaults.standard.set(prefs.notifAnswer, forKey: "notification.r1")
+                UserDefaults.standard.set(prefs.notifNudge, forKey: "notification.r3")
+                UserDefaults.standard.set(prefs.notifQuestion, forKey: "notification.r5")
+                UserDefaults.standard.set(prefs.quietHoursEnabled, forKey: "notification.quietHours")
+                return .none
+
+            case .loadFailed:
+                state.isLoading = false
+                return .none
+
             case .closeTapped:
                 return .send(.delegate(.close))
 
@@ -62,14 +123,34 @@ public struct NotificationSettingsFeature {
                     state.notificationItems[index].isOn = isOn
                     UserDefaults.standard.set(isOn, forKey: "notification.\(id)")
                 }
-                return .none
+                let paramKey: String
+                switch id {
+                case "r1": paramKey = "notifAnswer"
+                case "r3": paramKey = "notifNudge"
+                case "r5": paramKey = "notifQuestion"
+                default: return .none
+                }
+                return .run { [userRepository] _ in
+                    _ = try? await userRepository.updateNotificationPreferences([paramKey: isOn])
+                }
 
             case .quietHoursToggleChanged(let isOn):
                 state.quietHoursEnabled = isOn
                 UserDefaults.standard.set(isOn, forKey: "notification.quietHours")
-                return .none
+                return .run { [userRepository] _ in
+                    _ = try? await userRepository.updateNotificationPreferences(["quietHoursEnabled": isOn])
+                }
 
-            case .delegate:
+            case .openSystemSettingsTapped:
+                return .run { _ in
+                    await MainActor.run {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    }
+                }
+
+            case .serverUpdateCompleted, .delegate:
                 return .none
             }
         }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/NotificationSettingsFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/NotificationSettingsFeature.swift
@@ -28,6 +28,8 @@ public struct NotificationSettingsFeature {
         public var isLoading: Bool = true
         /// 시스템 알림이 차단된 상태인지 (배너 표시용)
         public var isSystemNotificationDenied: Bool = false
+        /// 알림 설정 저장 실패 시 토스트 표시
+        public var showSaveError: Bool = false
 
         public init() {
             let ud = UserDefaults.standard
@@ -55,6 +57,9 @@ public struct NotificationSettingsFeature {
         case quietHoursToggleChanged(Bool)
         case openSystemSettingsTapped
         case serverUpdateCompleted
+        case saveFailedRollback(id: String, previousValue: Bool)
+        case quietHoursSaveFailedRollback(previousValue: Bool)
+        case dismissSaveError
         case delegate(Delegate)
 
         public enum Delegate: Sendable, Equatable {
@@ -119,6 +124,7 @@ public struct NotificationSettingsFeature {
                 return .send(.delegate(.close))
 
             case .toggleChanged(let id, let isOn):
+                let previousValue = state.notificationItems.first(where: { $0.id == id })?.isOn ?? !isOn
                 if let index = state.notificationItems.firstIndex(where: { $0.id == id }) {
                     state.notificationItems[index].isOn = isOn
                     UserDefaults.standard.set(isOn, forKey: "notification.\(id)")
@@ -130,16 +136,49 @@ public struct NotificationSettingsFeature {
                 case "r5": paramKey = "notifQuestion"
                 default: return .none
                 }
-                return .run { [userRepository] _ in
-                    _ = try? await userRepository.updateNotificationPreferences([paramKey: isOn])
+                return .run { [userRepository] send in
+                    do {
+                        _ = try await userRepository.updateNotificationPreferences([paramKey: isOn])
+                    } catch {
+                        await send(.saveFailedRollback(id: id, previousValue: previousValue))
+                    }
+                }
+
+            case .saveFailedRollback(let id, let previousValue):
+                if let index = state.notificationItems.firstIndex(where: { $0.id == id }) {
+                    state.notificationItems[index].isOn = previousValue
+                    UserDefaults.standard.set(previousValue, forKey: "notification.\(id)")
+                }
+                state.showSaveError = true
+                return .run { send in
+                    try await Task.sleep(nanoseconds: 2_000_000_000)
+                    await send(.dismissSaveError)
                 }
 
             case .quietHoursToggleChanged(let isOn):
+                let previousValue = state.quietHoursEnabled
                 state.quietHoursEnabled = isOn
                 UserDefaults.standard.set(isOn, forKey: "notification.quietHours")
-                return .run { [userRepository] _ in
-                    _ = try? await userRepository.updateNotificationPreferences(["quietHoursEnabled": isOn])
+                return .run { [userRepository] send in
+                    do {
+                        _ = try await userRepository.updateNotificationPreferences(["quietHoursEnabled": isOn])
+                    } catch {
+                        await send(.quietHoursSaveFailedRollback(previousValue: previousValue))
+                    }
                 }
+
+            case .quietHoursSaveFailedRollback(let previousValue):
+                state.quietHoursEnabled = previousValue
+                UserDefaults.standard.set(previousValue, forKey: "notification.quietHours")
+                state.showSaveError = true
+                return .run { send in
+                    try await Task.sleep(nanoseconds: 2_000_000_000)
+                    await send(.dismissSaveError)
+                }
+
+            case .dismissSaveError:
+                state.showSaveError = false
+                return .none
 
             case .openSystemSettingsTapped:
                 return .run { _ in

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/NotificationSettingsView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/NotificationSettingsView.swift
@@ -18,6 +18,11 @@ public struct NotificationSettingsView: View {
 
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: MongleSpacing.md) {
+                    // 시스템 알림 차단 경고 배너
+                    if store.isSystemNotificationDenied {
+                        systemNotificationBanner
+                    }
+
                     settingsSection(title: L10n.tr("notif_settings_answer"), items: Array(store.notificationItems.prefix(1)))
                     settingsSection(title: L10n.tr("notif_settings_nudge"), items: Array(store.notificationItems.dropFirst(1).prefix(1)))
                     settingsSection(title: L10n.tr("notif_settings_system"), items: Array(store.notificationItems.dropFirst(2)))
@@ -51,6 +56,40 @@ public struct NotificationSettingsView: View {
             .background(MongleColor.background)
         }
         .toolbar(.hidden, for: .navigationBar)
+        .onAppear { store.send(.onAppear) }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            store.send(.scenePhaseActive)
+        }
+    }
+
+    /// 시스템 알림이 꺼져있을 때 표시하는 경고 배너
+    private var systemNotificationBanner: some View {
+        HStack(spacing: MongleSpacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(MongleColor.error)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L10n.tr("notif_system_off_title"))
+                    .font(MongleFont.body2Bold())
+                    .foregroundColor(MongleColor.textPrimary)
+                Text(L10n.tr("notif_system_off_desc"))
+                    .font(MongleFont.caption())
+                    .foregroundColor(MongleColor.textSecondary)
+            }
+            Spacer()
+            Button {
+                store.send(.openSystemSettingsTapped)
+            } label: {
+                Text(L10n.tr("notif_system_off_button"))
+                    .font(MongleFont.captionBold())
+                    .foregroundColor(.white)
+                    .padding(.horizontal, MongleSpacing.sm)
+                    .padding(.vertical, MongleSpacing.xxs)
+                    .background(MongleColor.primary)
+                    .cornerRadius(MongleRadius.medium)
+            }
+        }
+        .padding(MongleSpacing.md)
+        .monglePanel(background: MongleColor.error.opacity(0.08), cornerRadius: MongleRadius.large, borderColor: MongleColor.error.opacity(0.3), shadowOpacity: 0)
     }
 
     private func settingsSection(title: String, items: [NotificationSettingsFeature.State.ToggleItem]) -> some View {

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/NotificationSettingsView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/NotificationSettingsView.swift
@@ -56,6 +56,14 @@ public struct NotificationSettingsView: View {
             .background(MongleColor.background)
         }
         .toolbar(.hidden, for: .navigationBar)
+        .overlay(alignment: .bottom) {
+            if store.showSaveError {
+                MongleToastView(type: .appError(.domain(L10n.tr("toast_notif_save_error"))))
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .padding(.bottom, MongleSpacing.xl)
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: store.showSaveError)
         .onAppear { store.send(.onAppear) }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             store.send(.scenePhaseActive)

--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -334,6 +334,7 @@
 "toast_already_member" = "Already a member";
 "toast_invalid_code" = "Please check the invite code";
 "toast_custom_question_exists" = "A family member already posted today's question";
+"toast_notif_save_error" = "Failed to save notification settings. Please try again";
 
 /* Error Messages */
 "error_title" = "Error";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -318,6 +318,9 @@
 "notif_settings_nudge_detail" = "Notify when you receive a nudge";
 "notif_settings_question_desc" = "New question notification";
 "notif_settings_question_detail" = "Notify when new daily question arrives";
+"notif_system_off_title" = "System notifications are off";
+"notif_system_off_desc" = "Please enable notifications in system settings to receive alerts";
+"notif_system_off_button" = "Go to Settings";
 
 /* Toast Messages */
 "toast_skip" = "Question skipped. Check other answers!";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -318,6 +318,9 @@
 "notif_settings_nudge_detail" = "メンバーから回答催促を受けたら通知";
 "notif_settings_question_desc" = "新しい質問通知";
 "notif_settings_question_detail" = "毎朝新しい質問が登録されたら通知";
+"notif_system_off_title" = "システム通知がオフです";
+"notif_system_off_desc" = "通知を受け取るにはシステム設定で通知を許可してください";
+"notif_system_off_button" = "設定へ移動";
 
 /* Toast Messages */
 "toast_skip" = "質問をスキップしました。他のメンバーの回答を確認しましょう！";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -334,6 +334,7 @@
 "toast_already_member" = "すでに参加しているグループです";
 "toast_invalid_code" = "招待コードを再確認してください";
 "toast_custom_question_exists" = "すでに家族が今日の質問を投稿しました";
+"toast_notif_save_error" = "通知設定の保存に失敗しました。もう一度お試しください";
 
 /* Error Messages */
 "error_title" = "エラー";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -318,6 +318,9 @@
 "notif_settings_nudge_detail" = "맴버에게 답변 재촉 알림을 받으면 알림";
 "notif_settings_question_desc" = "새 질문 알림";
 "notif_settings_question_detail" = "매일 오전 새 질문이 등록되면 알림";
+"notif_system_off_title" = "시스템 알림이 꺼져있어요";
+"notif_system_off_desc" = "알림을 받으려면 시스템 설정에서 알림을 허용해주세요";
+"notif_system_off_button" = "설정으로 이동";
 
 /* Toast Messages */
 "toast_skip" = "질문을 넘겼어요. 다른 멤버 답변을 확인해보세요!";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -334,6 +334,7 @@
 "toast_already_member" = "이미 속해있는 그룹이에요";
 "toast_invalid_code" = "초대코드를 다시 확인해주세요";
 "toast_custom_question_exists" = "이미 가족이 오늘의 질문을 등록했어요";
+"toast_notif_save_error" = "알림 설정 저장에 실패했어요. 다시 시도해주세요";
 
 /* Error Messages */
 "error_title" = "오류";

--- a/Work.md
+++ b/Work.md
@@ -1,195 +1,50 @@
 # 작업
 
-아래 이슈를 확인하고 수정할 것
-- 노션에 티켓 발급 후 버그리포트 작성
-- iOS 에이전트가 수정 후 QA 에이전트에게 컨펌받을 것
+## 이슈 목록 및 처리 현황 (2026-04-13)
+
+### Bug 1: 알림설정(답변/재촉/시스템) 변경이 푸시 발송에 반영되지 않음 — P0
+- **현상**: 알림설정 화면에서 답변알림·재촉알림·시스템알림을 OFF해도 푸시가 계속 수신됨
+- **재현**: 재촉 알림 OFF → 상대방이 재촉하기 실행 → 알림 수신됨
+- **노션 티켓**: [Bug] 알림설정(답변/재촉/시스템) 변경이 실제 푸시 발송에 반영되지 않음
+
+**근본 원인 분석:**
+1. 서버(MongleServer)에 알림 선호도 체크 로직은 정상 구현되어 있음:
+   - `NudgeService.ts:76` — `if (target.notifNudge)` 체크
+   - `AnswerService.ts:117` — `if (member.notifAnswer)` 체크
+   - `scheduler.ts:122` — `if (!target.notifQuestion) continue` 체크
+2. 커밋 `70f4f83`(알림 선호도 API + 푸시 필터링)이 Lambda 배포(21:46 KST) 이후(21:51 KST)에 커밋됨
+3. **서버 재배포로 해결** — `deploy:dev` 실행 완료, `deploy:prod`는 이미 최신 배포 확인(No changes)
+
+**iOS 추가 수정:**
+- `NotificationSettingsFeature.swift` — `try?`를 `do/catch`로 변경, API 실패 시 토글 롤백 + 에러 토스트 표시
+- 로컬라이제이션 추가: `toast_notif_save_error` (ko/en/ja)
+- **빌드 확인: BUILD SUCCEEDED**
+
+**상태: ✅ 완료 (서버 배포 확인 + iOS 에러핸들링 개선)**
 
 ---
 
-## BUG-01: 로그아웃 후 다른 계정 알림 수신 (Critical)
+### Bug 2: 알림 텍스트에 나뭇잎(🌿) 이모지 잔존 — P1
+- **현상**: 푸시 알림 텍스트(재촉하기 등)에 🌿 이모지가 표시됨
+- **노션 티켓**: [Bug] 알림 텍스트에 나뭇잎(🌿) 이모지 잔존
 
-**현상:** 아이폰에서 로그아웃하고 다른 계정으로 로그인해도, 이전 계정의 알림이 계속 수신됨
+**근본 원인 분석:**
+- 서버 코드(`src/utils/i18n/push.ts`)에서 커밋 `bf2e909`로 이미 🌿 제거 완료
+- Bug 1과 동일한 배포 타이밍 이슈
 
-**근본 원인:** 서버 로그아웃 시 device token을 삭제하지 않음
-- `POST /auth/logout` → 단순히 `{ message: '로그아웃 되었습니다.' }` 반환만 함
-- `User.apnsToken` / `User.fcmToken` 필드를 null 처리하지 않음
-- 동일 디바이스 = 동일 APNs 토큰 → 이전 유저 DB에 토큰이 남아있어 양쪽 모두 푸시 수신
-
-**관련 코드:**
-- 서버: `MongleServer/src/controllers/AuthController.ts:89-93` — logout 핸들러 (토큰 정리 없음)
-- iOS: `Root+Reducer.swift:296-308` — logout action (서버에 토큰 삭제 요청 없음)
-- 서버: `MongleServer/src/services/UserService.ts` — registerDeviceToken (덮어쓰기만, 이전 유저 정리 없음)
-
-**수정 방안:**
-1. **서버**: `AuthController.logout()` 에서 `User.apnsToken = null`, `User.fcmToken = null` 업데이트
-2. **서버**: `registerDeviceToken()` 호출 시, 동일 토큰을 가진 다른 유저의 토큰을 null 처리 (중복 방지)
-3. **iOS**: logout action에서 서버에 토큰 삭제 API 호출 (또는 logout 전에 `PATCH /users/me/device-token` body `{"token": null}`)
+**상태: ✅ 완료 (서버 재배포로 해결, 코드 변경 불필요)**
 
 ---
 
-## BUG-02: 앱 내 알림 설정이 서버에 반영되지 않음 (High)
-
-**현상:** 앱 내 알림 설정(답변 알림, 재촉하기 알림, 새 질문 알림)을 끄거나 켜도 실제 푸시 알림 발송에 영향 없음
-
-**근본 원인:** 알림 설정이 클라이언트 UserDefaults에만 저장되고, 서버에 전달되지 않음
-- `NotificationSettingsFeature.swift:60-64` — UserDefaults에만 `notification.r1/r3/r5` 저장
-- 서버에 알림 선호도 API/모델이 존재하지 않음
-- 서버의 `PushNotificationService`는 무조건 푸시 발송 (선호도 체크 없음)
-- 방해 금지 시간(`notification.quietHours`)도 클라이언트에만 존재
-
-**수정 방안:**
-1. **서버**: `User` 또는 `FamilyMembership` 모델에 알림 선호도 필드 추가
-   - `notifAnswer: Boolean` (구성원 답변 알림)
-   - `notifNudge: Boolean` (재촉하기 알림)
-   - `notifQuestion: Boolean` (새 질문 알림)
-   - `quietHoursEnabled: Boolean`, `quietHoursStart: String`, `quietHoursEnd: String`
-2. **서버**: `PATCH /users/me/notification-preferences` 엔드포인트 생성
-3. **서버**: `PushNotificationService` 발송 전 수신자의 알림 선호도 체크 로직 추가
-4. **iOS**: `NotificationSettingsFeature`에서 토글 변경 시 서버 API 호출 추가
+### 수정 파일 요약
+| 위치 | 파일 | 변경 내용 |
+|------|------|-----------|
+| iOS | `NotificationSettingsFeature.swift` | try? → do/catch, 실패 시 롤백 + 에러 토스트 |
+| iOS | `NotificationSettingsView.swift` | 에러 토스트 오버레이 추가 |
+| iOS | `ko/en/ja Localizable.strings` | `toast_notif_save_error` 문자열 추가 |
+| Server | (코드 변경 없음) | dev 재배포 완료, prod 최신 확인 |
 
 ---
-
-## BUG-03: 시스템 알림 차단 시 앱 내 설정과 비동기화 (High)
-
-**현상:**
-1. 앱에서 처음 알림을 거부 → iOS가 다시 묻지 않음
-2. 앱 내 설정에서 알림을 켜도 시스템에 반영 안됨
-3. 시스템 설정에서 알림을 켜도 앱이 이를 감지하지 못함
-
-**근본 원인:** 시스템 알림 권한 상태를 체크하지 않음
-- `UNUserNotificationCenter.current().getNotificationSettings()` 호출이 없음
-- 앱 내 설정 UI에 시스템 알림 권한 상태 표시 없음
-- 시스템에서 알림 거부 후 → 앱이 `UIApplication.openSettingsURLString`으로 안내하지 않음
-- iOS 정책: `requestAuthorization()`은 최초 1회만 시스템 팝업 표시, 이후 거부 시 직접 설정 앱으로 이동해야 함
-
-**관련 코드:**
-- iOS: `Root+Reducer.swift:248-259` — 최초 1회만 권한 요청 (`mongle.didRequestPushPermission` 플래그)
-- iOS: `NotificationSettingsView.swift` — 시스템 권한 상태 표시 없음
-- iOS: `GroupSelectView+NotificationPermission.swift` — "허용하기"/"나중에" 선택지만 있고 시스템 설정 안내 없음
-
-**수정 방안:**
-1. **iOS**: `NotificationSettingsFeature`에 시스템 알림 권한 상태 체크 추가
-   ```swift
-   UNUserNotificationCenter.current().getNotificationSettings { settings in
-       if settings.authorizationStatus == .denied {
-           // 시스템 설정으로 이동 안내 배너 표시
-       }
-   }
-   ```
-2. **iOS**: 시스템 알림이 꺼져있을 때 설정 화면 상단에 경고 배너 + "시스템 설정으로 이동" 버튼 추가
-   ```swift
-   UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
-   ```
-3. **iOS**: 앱이 foreground로 돌아올 때 (`scenePhase == .active`) 알림 권한 상태 재확인
-4. **iOS**: 그룹 내 알림 설정 변경 시에도 시스템 알림 상태를 먼저 체크하여 꺼져있으면 시스템 설정 유도
-
----
-
-## BUG-04: 재촉하기 알림 미수신 (Medium)
-
-**현상:** 재촉하기(Nudge) 기능 사용 시 하트는 차감되지만 상대방에게 푸시 알림이 도착하지 않음
-
-**분석:**
-- `NudgeService.ts:73-96` — Lambda 환경에서 `await Promise.all(pushTasks)` 호출 (이전 비동기 이슈 수정 완료)
-- 가능한 원인들:
-  1. 수신자의 `apnsToken`이 null (토큰 미등록 또는 BUG-01로 인한 토큰 불일치)
-  2. APNs 인증서/키 만료 또는 환경변수 미설정
-  3. `PushNotificationService`의 APNs HTTP/2 연결 실패 (Lambda cold start)
-  4. 수신자의 시스템 알림이 꺼져있음 (BUG-03)
-
-**관련 코드:**
-- 서버: `MongleServer/src/services/NudgeService.ts:76-96` — 푸시 발송 (에러 catch 후 warn 로그만)
-- 서버: `MongleServer/src/services/PushNotificationService.ts` — APNs/FCM 실제 발송
-- iOS: `PeerNudgeFeature.swift` — 재촉하기 UI
-
-**수정 방안:**
-1. **서버**: 푸시 실패 시 로그 레벨을 `warn` → `error`로 올리고 실패 원인 상세 기록
-2. **서버**: APNs 토큰 유효성 검증 — 410 Gone 응답 시 토큰 자동 삭제
-3. **서버**: 푸시 발송 결과를 클라이언트에 반환 (`pushSent: boolean` 필드 추가)
-4. **BUG-01 수정 후 재검증** — 토큰 정리가 되면 자연스럽게 해결될 가능성 높음
-
----
-
-## BUG-05: 전반적인 푸시 알림 미수신 (Medium)
-
-**현상:** 새 질문 알림, 답변 알림 등 전반적으로 푸시 알림이 도착하지 않음
-
-**분석:**
-- BUG-01 ~ BUG-04의 복합 원인일 가능성 높음
-- 추가 확인 필요 사항:
-  1. APNs 환경변수 설정 확인 (`APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_PRIVATE_KEY` 등)
-  2. Lambda 스케줄러 (`scheduler.ts`, `reminderScheduler.ts`) 정상 동작 여부
-  3. APNs 프로덕션 vs 샌드박스 환경 불일치
-  4. FCM 설정 확인 (Android용)
-
-**수정 방안:**
-1. **서버**: 푸시 발송 Health Check 엔드포인트 추가 (관리자용)
-2. **서버**: 푸시 실패 로그를 CloudWatch/모니터링 시스템에 연동
-3. **서버**: APNs 토큰 유효성 검증 + 만료 토큰 자동 정리 로직 추가
-
----
-
-## BUG-06: 그룹 알림 설정 시 시스템 알림 유도 (Feature Request)
-
-**현상:** 각 그룹에서 알림 설정을 할 때, 앱 자체 알림이 꺼져있으면 시스템 알림 허용 프롬프트를 보여주길 원함
-
-**현재 동작:** 그룹 최초 진입 시 1회 알림 권한 요청 (`mongle.notifSetup.<familyId>` 플래그)만 존재
-
-**수정 방안:**
-1. **iOS**: 그룹 알림 토글 ON 시 시스템 알림 상태 체크
-2. 시스템 알림이 `.denied`이면 "알림을 받으려면 시스템 설정에서 알림을 허용해주세요" Alert 표시
-3. Alert에 "설정으로 이동" 버튼 → `UIApplication.openSettingsURLString`
-4. `.notDetermined`이면 `requestAuthorization()` 호출 (iOS가 시스템 팝업 표시)
-
----
-
-## BUG-07: 그룹 나가기 일수 카운팅 오류 (Medium)
-
-**현상:** 그룹 나가기 시 남은 일수가 제대로 카운팅되지 않음 (항상 3일로 표시될 수 있음)
-
-**현재 구현 분석:**
-- **클라이언트** (`GroupManagementFeature.swift:151-158`, `GroupSelectFeature.swift:425-428`):
-  ```swift
-  let hoursSinceCreation = Date().timeIntervalSince(createdAt) / 3600
-  if hoursSinceCreation < 72 {
-      let daysLeft = Int(ceil((72 - hoursSinceCreation) / 24))
-  }
-  ```
-- **서버** (`FamilyService.ts:346-351`):
-  ```typescript
-  const hoursSinceCreation = (Date.now() - family.createdAt.getTime()) / (1000 * 60 * 60);
-  if (hoursSinceCreation < 72) {
-      const daysLeft = Math.ceil((72 - hoursSinceCreation) / 24);
-  }
-  ```
-- 로직 자체는 올바름: `createdAt` 기준으로 경과 시간 계산 → 72시간 미만이면 남은 일수 표시
-
-**의심되는 원인:**
-1. **`createdAt` 타임존 불일치**: 서버가 UTC로 저장하는데 iOS가 로컬 타임존으로 해석할 경우
-   - 예: KST(+9) 환경에서 UTC `createdAt`을 로컬로 해석하면 9시간 차이 발생
-   - 실제 24시간 지남 → 클라이언트는 15시간만 지난 것으로 계산 → 3일 유지
-2. **`createdAt` null/미전달**: API 응답에서 `createdAt`이 누락되면 기본값으로 현재 시각 사용 가능
-3. **JSON 날짜 파싱 오류**: ISO 8601 문자열을 Swift `Date`로 변환 시 포맷 불일치
-
-**확인할 사항:**
-1. 서버 API에서 `createdAt` 필드가 정상적으로 반환되는지 (ISO 8601 with timezone)
-2. iOS `MongleGroup.createdAt` 파싱이 정확한지 (DateFormatter/JSONDecoder dateDecodingStrategy)
-3. 실제 3일 경과 후에도 서버에서 거부하는지 (서버 로그 확인)
-
-**수정 방안 (원래 요구사항 반영):**
-> "처음 그룹을 생성하고 삭제관련필드 3으로 만들고 하루 지날때마다 -1하고 0이 되면 삭제하도록"
-
-현재 구현은 별도 필드 없이 `createdAt` 기준 실시간 계산 방식이므로, 두 가지 선택지:
-
-**Option A — 현재 방식 유지 + 버그 수정 (권장):**
-- 타임존 파싱 문제 수정 (서버는 UTC ISO 8601로 통일, iOS는 UTC 기준 파싱)
-- 이 방식이 더 정확하고 별도 스케줄러 불필요
-
-**Option B — 카운트다운 필드 방식 (요구사항대로):**
-- 서버: `Family` 모델에 `deletionCountdown: Int` 필드 추가 (기본값 3)
-- 서버: 매일 자정 스케줄러로 `deletionCountdown -= 1` 실행
-- 서버: `deletionCountdown == 0`이면 그룹장 나가기 허용
-- 단점: 스케줄러 추가 필요, 시간 기반보다 정밀도 낮음
 
 ## 위치
 - 디자인: /Users/yong/Desktop/FamTree/MongleUI

--- a/Work.md
+++ b/Work.md
@@ -1,9 +1,195 @@
 # 작업
 
-개별알림 터치
-- 현재 개별알림 터치 시 화면이동은 되는데 터치한 알림에 대해 해당 알림이 사라지지 않는 문제가 있음 이걸 버그티켓을 발급받아서 진행하고 qa에이전트에게 실기기테스트를 받도록해
-- zxx 그룹에서 재촉하기 알림을 눌렀는데 삭제되지 않고 알림화면에 계속 살아있는 오류가 있음
-  - 데이터베이스 서버에서 해당 내용을 삭제해 더 이상 불러오지 못하게 수정
+아래 이슈를 확인하고 수정할 것
+- 노션에 티켓 발급 후 버그리포트 작성
+- iOS 에이전트가 수정 후 QA 에이전트에게 컨펌받을 것
+
+---
+
+## BUG-01: 로그아웃 후 다른 계정 알림 수신 (Critical)
+
+**현상:** 아이폰에서 로그아웃하고 다른 계정으로 로그인해도, 이전 계정의 알림이 계속 수신됨
+
+**근본 원인:** 서버 로그아웃 시 device token을 삭제하지 않음
+- `POST /auth/logout` → 단순히 `{ message: '로그아웃 되었습니다.' }` 반환만 함
+- `User.apnsToken` / `User.fcmToken` 필드를 null 처리하지 않음
+- 동일 디바이스 = 동일 APNs 토큰 → 이전 유저 DB에 토큰이 남아있어 양쪽 모두 푸시 수신
+
+**관련 코드:**
+- 서버: `MongleServer/src/controllers/AuthController.ts:89-93` — logout 핸들러 (토큰 정리 없음)
+- iOS: `Root+Reducer.swift:296-308` — logout action (서버에 토큰 삭제 요청 없음)
+- 서버: `MongleServer/src/services/UserService.ts` — registerDeviceToken (덮어쓰기만, 이전 유저 정리 없음)
+
+**수정 방안:**
+1. **서버**: `AuthController.logout()` 에서 `User.apnsToken = null`, `User.fcmToken = null` 업데이트
+2. **서버**: `registerDeviceToken()` 호출 시, 동일 토큰을 가진 다른 유저의 토큰을 null 처리 (중복 방지)
+3. **iOS**: logout action에서 서버에 토큰 삭제 API 호출 (또는 logout 전에 `PATCH /users/me/device-token` body `{"token": null}`)
+
+---
+
+## BUG-02: 앱 내 알림 설정이 서버에 반영되지 않음 (High)
+
+**현상:** 앱 내 알림 설정(답변 알림, 재촉하기 알림, 새 질문 알림)을 끄거나 켜도 실제 푸시 알림 발송에 영향 없음
+
+**근본 원인:** 알림 설정이 클라이언트 UserDefaults에만 저장되고, 서버에 전달되지 않음
+- `NotificationSettingsFeature.swift:60-64` — UserDefaults에만 `notification.r1/r3/r5` 저장
+- 서버에 알림 선호도 API/모델이 존재하지 않음
+- 서버의 `PushNotificationService`는 무조건 푸시 발송 (선호도 체크 없음)
+- 방해 금지 시간(`notification.quietHours`)도 클라이언트에만 존재
+
+**수정 방안:**
+1. **서버**: `User` 또는 `FamilyMembership` 모델에 알림 선호도 필드 추가
+   - `notifAnswer: Boolean` (구성원 답변 알림)
+   - `notifNudge: Boolean` (재촉하기 알림)
+   - `notifQuestion: Boolean` (새 질문 알림)
+   - `quietHoursEnabled: Boolean`, `quietHoursStart: String`, `quietHoursEnd: String`
+2. **서버**: `PATCH /users/me/notification-preferences` 엔드포인트 생성
+3. **서버**: `PushNotificationService` 발송 전 수신자의 알림 선호도 체크 로직 추가
+4. **iOS**: `NotificationSettingsFeature`에서 토글 변경 시 서버 API 호출 추가
+
+---
+
+## BUG-03: 시스템 알림 차단 시 앱 내 설정과 비동기화 (High)
+
+**현상:**
+1. 앱에서 처음 알림을 거부 → iOS가 다시 묻지 않음
+2. 앱 내 설정에서 알림을 켜도 시스템에 반영 안됨
+3. 시스템 설정에서 알림을 켜도 앱이 이를 감지하지 못함
+
+**근본 원인:** 시스템 알림 권한 상태를 체크하지 않음
+- `UNUserNotificationCenter.current().getNotificationSettings()` 호출이 없음
+- 앱 내 설정 UI에 시스템 알림 권한 상태 표시 없음
+- 시스템에서 알림 거부 후 → 앱이 `UIApplication.openSettingsURLString`으로 안내하지 않음
+- iOS 정책: `requestAuthorization()`은 최초 1회만 시스템 팝업 표시, 이후 거부 시 직접 설정 앱으로 이동해야 함
+
+**관련 코드:**
+- iOS: `Root+Reducer.swift:248-259` — 최초 1회만 권한 요청 (`mongle.didRequestPushPermission` 플래그)
+- iOS: `NotificationSettingsView.swift` — 시스템 권한 상태 표시 없음
+- iOS: `GroupSelectView+NotificationPermission.swift` — "허용하기"/"나중에" 선택지만 있고 시스템 설정 안내 없음
+
+**수정 방안:**
+1. **iOS**: `NotificationSettingsFeature`에 시스템 알림 권한 상태 체크 추가
+   ```swift
+   UNUserNotificationCenter.current().getNotificationSettings { settings in
+       if settings.authorizationStatus == .denied {
+           // 시스템 설정으로 이동 안내 배너 표시
+       }
+   }
+   ```
+2. **iOS**: 시스템 알림이 꺼져있을 때 설정 화면 상단에 경고 배너 + "시스템 설정으로 이동" 버튼 추가
+   ```swift
+   UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+   ```
+3. **iOS**: 앱이 foreground로 돌아올 때 (`scenePhase == .active`) 알림 권한 상태 재확인
+4. **iOS**: 그룹 내 알림 설정 변경 시에도 시스템 알림 상태를 먼저 체크하여 꺼져있으면 시스템 설정 유도
+
+---
+
+## BUG-04: 재촉하기 알림 미수신 (Medium)
+
+**현상:** 재촉하기(Nudge) 기능 사용 시 하트는 차감되지만 상대방에게 푸시 알림이 도착하지 않음
+
+**분석:**
+- `NudgeService.ts:73-96` — Lambda 환경에서 `await Promise.all(pushTasks)` 호출 (이전 비동기 이슈 수정 완료)
+- 가능한 원인들:
+  1. 수신자의 `apnsToken`이 null (토큰 미등록 또는 BUG-01로 인한 토큰 불일치)
+  2. APNs 인증서/키 만료 또는 환경변수 미설정
+  3. `PushNotificationService`의 APNs HTTP/2 연결 실패 (Lambda cold start)
+  4. 수신자의 시스템 알림이 꺼져있음 (BUG-03)
+
+**관련 코드:**
+- 서버: `MongleServer/src/services/NudgeService.ts:76-96` — 푸시 발송 (에러 catch 후 warn 로그만)
+- 서버: `MongleServer/src/services/PushNotificationService.ts` — APNs/FCM 실제 발송
+- iOS: `PeerNudgeFeature.swift` — 재촉하기 UI
+
+**수정 방안:**
+1. **서버**: 푸시 실패 시 로그 레벨을 `warn` → `error`로 올리고 실패 원인 상세 기록
+2. **서버**: APNs 토큰 유효성 검증 — 410 Gone 응답 시 토큰 자동 삭제
+3. **서버**: 푸시 발송 결과를 클라이언트에 반환 (`pushSent: boolean` 필드 추가)
+4. **BUG-01 수정 후 재검증** — 토큰 정리가 되면 자연스럽게 해결될 가능성 높음
+
+---
+
+## BUG-05: 전반적인 푸시 알림 미수신 (Medium)
+
+**현상:** 새 질문 알림, 답변 알림 등 전반적으로 푸시 알림이 도착하지 않음
+
+**분석:**
+- BUG-01 ~ BUG-04의 복합 원인일 가능성 높음
+- 추가 확인 필요 사항:
+  1. APNs 환경변수 설정 확인 (`APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_PRIVATE_KEY` 등)
+  2. Lambda 스케줄러 (`scheduler.ts`, `reminderScheduler.ts`) 정상 동작 여부
+  3. APNs 프로덕션 vs 샌드박스 환경 불일치
+  4. FCM 설정 확인 (Android용)
+
+**수정 방안:**
+1. **서버**: 푸시 발송 Health Check 엔드포인트 추가 (관리자용)
+2. **서버**: 푸시 실패 로그를 CloudWatch/모니터링 시스템에 연동
+3. **서버**: APNs 토큰 유효성 검증 + 만료 토큰 자동 정리 로직 추가
+
+---
+
+## BUG-06: 그룹 알림 설정 시 시스템 알림 유도 (Feature Request)
+
+**현상:** 각 그룹에서 알림 설정을 할 때, 앱 자체 알림이 꺼져있으면 시스템 알림 허용 프롬프트를 보여주길 원함
+
+**현재 동작:** 그룹 최초 진입 시 1회 알림 권한 요청 (`mongle.notifSetup.<familyId>` 플래그)만 존재
+
+**수정 방안:**
+1. **iOS**: 그룹 알림 토글 ON 시 시스템 알림 상태 체크
+2. 시스템 알림이 `.denied`이면 "알림을 받으려면 시스템 설정에서 알림을 허용해주세요" Alert 표시
+3. Alert에 "설정으로 이동" 버튼 → `UIApplication.openSettingsURLString`
+4. `.notDetermined`이면 `requestAuthorization()` 호출 (iOS가 시스템 팝업 표시)
+
+---
+
+## BUG-07: 그룹 나가기 일수 카운팅 오류 (Medium)
+
+**현상:** 그룹 나가기 시 남은 일수가 제대로 카운팅되지 않음 (항상 3일로 표시될 수 있음)
+
+**현재 구현 분석:**
+- **클라이언트** (`GroupManagementFeature.swift:151-158`, `GroupSelectFeature.swift:425-428`):
+  ```swift
+  let hoursSinceCreation = Date().timeIntervalSince(createdAt) / 3600
+  if hoursSinceCreation < 72 {
+      let daysLeft = Int(ceil((72 - hoursSinceCreation) / 24))
+  }
+  ```
+- **서버** (`FamilyService.ts:346-351`):
+  ```typescript
+  const hoursSinceCreation = (Date.now() - family.createdAt.getTime()) / (1000 * 60 * 60);
+  if (hoursSinceCreation < 72) {
+      const daysLeft = Math.ceil((72 - hoursSinceCreation) / 24);
+  }
+  ```
+- 로직 자체는 올바름: `createdAt` 기준으로 경과 시간 계산 → 72시간 미만이면 남은 일수 표시
+
+**의심되는 원인:**
+1. **`createdAt` 타임존 불일치**: 서버가 UTC로 저장하는데 iOS가 로컬 타임존으로 해석할 경우
+   - 예: KST(+9) 환경에서 UTC `createdAt`을 로컬로 해석하면 9시간 차이 발생
+   - 실제 24시간 지남 → 클라이언트는 15시간만 지난 것으로 계산 → 3일 유지
+2. **`createdAt` null/미전달**: API 응답에서 `createdAt`이 누락되면 기본값으로 현재 시각 사용 가능
+3. **JSON 날짜 파싱 오류**: ISO 8601 문자열을 Swift `Date`로 변환 시 포맷 불일치
+
+**확인할 사항:**
+1. 서버 API에서 `createdAt` 필드가 정상적으로 반환되는지 (ISO 8601 with timezone)
+2. iOS `MongleGroup.createdAt` 파싱이 정확한지 (DateFormatter/JSONDecoder dateDecodingStrategy)
+3. 실제 3일 경과 후에도 서버에서 거부하는지 (서버 로그 확인)
+
+**수정 방안 (원래 요구사항 반영):**
+> "처음 그룹을 생성하고 삭제관련필드 3으로 만들고 하루 지날때마다 -1하고 0이 되면 삭제하도록"
+
+현재 구현은 별도 필드 없이 `createdAt` 기준 실시간 계산 방식이므로, 두 가지 선택지:
+
+**Option A — 현재 방식 유지 + 버그 수정 (권장):**
+- 타임존 파싱 문제 수정 (서버는 UTC ISO 8601로 통일, iOS는 UTC 기준 파싱)
+- 이 방식이 더 정확하고 별도 스케줄러 불필요
+
+**Option B — 카운트다운 필드 방식 (요구사항대로):**
+- 서버: `Family` 모델에 `deletionCountdown: Int` 필드 추가 (기본값 3)
+- 서버: 매일 자정 스케줄러로 `deletionCountdown -= 1` 실행
+- 서버: `deletionCountdown == 0`이면 그룹장 나가기 허용
+- 단점: 스케줄러 추가 필요, 시간 기반보다 정밀도 낮음
 
 ## 위치
 - 디자인: /Users/yong/Desktop/FamTree/MongleUI


### PR DESCRIPTION
 Summary
  - 알림 (답변/재촉/시스템) 서버 연동 및 시스템 알림 차단 상태 감지 추가           
  - 알림설정 저장 실패 시 토글 자동 롤백 + 에러 토스트 표시 (try? → do/catch)            
  - ISO 8601 밀리초 파싱 수정으로 그룹 나가기 일수 카운팅 오류 해결                      
  - 마케팅 버전 1.0.4 업데이트     