### PR TITLE
[MG-9] iOS: 초록 계열을 Asset Catalog Color Set으로 이동 + 파스텔 값 재지정

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MongleMonggleGreen.colorset/Contents.json
+++ b/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MongleMonggleGreen.colorset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0x8F",
+          "green" : "0xD5",
+          "blue" : "0xA6"
+        }
+      }
+    },
+    {
+      "appearances" : [
+        { "appearance" : "luminosity", "value" : "dark" }
+      ],
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0xA5",
+          "green" : "0xE0",
+          "blue" : "0xC0"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimary.colorset/Contents.json
+++ b/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimary.colorset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0x8F",
+          "green" : "0xD5",
+          "blue" : "0xA6"
+        }
+      }
+    },
+    {
+      "appearances" : [
+        { "appearance" : "luminosity", "value" : "dark" }
+      ],
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0xA5",
+          "green" : "0xE0",
+          "blue" : "0xC0"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimaryDark.colorset/Contents.json
+++ b/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimaryDark.colorset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0x5B",
+          "green" : "0xAF",
+          "blue" : "0x85"
+        }
+      }
+    },
+    {
+      "appearances" : [
+        { "appearance" : "luminosity", "value" : "dark" }
+      ],
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0x6B",
+          "green" : "0xBF",
+          "blue" : "0x93"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimaryGradientEnd.colorset/Contents.json
+++ b/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimaryGradientEnd.colorset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0xA5",
+          "green" : "0xE0",
+          "blue" : "0xC0"
+        }
+      }
+    },
+    {
+      "appearances" : [
+        { "appearance" : "luminosity", "value" : "dark" }
+      ],
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0xA5",
+          "green" : "0xE0",
+          "blue" : "0xC0"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimaryGradientStart.colorset/Contents.json
+++ b/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimaryGradientStart.colorset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0x8F",
+          "green" : "0xD5",
+          "blue" : "0xA6"
+        }
+      }
+    },
+    {
+      "appearances" : [
+        { "appearance" : "luminosity", "value" : "dark" }
+      ],
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0x8F",
+          "green" : "0xD5",
+          "blue" : "0xA6"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimaryLight.colorset/Contents.json
+++ b/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimaryLight.colorset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0xA5",
+          "green" : "0xD6",
+          "blue" : "0xA7"
+        }
+      }
+    },
+    {
+      "appearances" : [
+        { "appearance" : "luminosity", "value" : "dark" }
+      ],
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0xC2",
+          "green" : "0xE8",
+          "blue" : "0xD4"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimarySoft.colorset/Contents.json
+++ b/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MonglePrimarySoft.colorset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0x6B",
+          "green" : "0xBF",
+          "blue" : "0x93"
+        }
+      }
+    },
+    {
+      "appearances" : [
+        { "appearance" : "luminosity", "value" : "dark" }
+      ],
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0x8F",
+          "green" : "0xD5",
+          "blue" : "0xA6"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MongleSuccess.colorset/Contents.json
+++ b/MongleFeatures/Sources/MongleFeatures/Assets.xcassets/MongleSuccess.colorset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0x8F",
+          "green" : "0xD5",
+          "blue" : "0xA6"
+        }
+      }
+    },
+    {
+      "appearances" : [
+        { "appearance" : "luminosity", "value" : "dark" }
+      ],
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "red" : "0xA5",
+          "green" : "0xE0",
+          "blue" : "0xC0"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MongleFeatures/Sources/MongleFeatures/Design/DesignSystem.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Design/DesignSystem.swift
@@ -12,14 +12,16 @@ import UIKit
 
 public enum MongleColor {
     // Primary / Brand
-    public static let primary = Color(light: "4CAF50", dark: "7BC8A0")
-    public static let primaryLight = Color(light: "A5D6A7", dark: "C2E8D4")
-    public static let primaryDark = Color(light: "388E3C", dark: "5BAF85")
-    public static let primarySoft = Color(light: "43A047", dark: "6BBF93")
+    // iPhone 11 LCD 에서 Material Green 500(#4CAF50) 류 값이 과채도화되어 진한 초록으로 보이는 이슈 대응.
+    // 주요 초록 계열은 Asset Catalog Color Set(Display P3)으로 이동했고, 값도 iPhone 15 Pro 파스텔 기준으로 재지정.
+    public static let primary = Color("MonglePrimary", bundle: .module)
+    public static let primaryLight = Color("MonglePrimaryLight", bundle: .module)
+    public static let primaryDark = Color("MonglePrimaryDark", bundle: .module)
+    public static let primarySoft = Color("MonglePrimarySoft", bundle: .module)
 
     // Primary gradient (button, badge gradients)
-    public static let primaryGradientStart = Color(hex: "6BBF93")
-    public static let primaryGradientEnd = Color(hex: "7BC8A0")
+    public static let primaryGradientStart = Color("MonglePrimaryGradientStart", bundle: .module)
+    public static let primaryGradientEnd = Color("MonglePrimaryGradientEnd", bundle: .module)
     public static let primaryXLight = Color(hex: "C2E8D4")
     public static let primaryMuted = Color(hex: "5BAF85")
     public static let primaryDeep = Color(hex: "2E7D32")
@@ -80,12 +82,12 @@ public enum MongleColor {
     // Status
     public static let error = Color(hex: "F44336")
     public static let warning = Color(hex: "FF9800")
-    public static let success = Color(light: "4CAF50", dark: "66BB6A")
+    public static let success = Color("MongleSuccess", bundle: .module)
     public static let info = Color(hex: "42A5F5")
     public static let notificationDot = Color(hex: "F44336")
 
     // Monggle character colors
-    public static let monggleGreen = Color(light: "66BB6A", dark: "8DD4AE")
+    public static let monggleGreen = Color("MongleMonggleGreen", bundle: .module)
     public static let monggleYellow = Color(hex: "FFD54F")
     public static let monggleBlue = Color(hex: "42A5F5")
     public static let mongglePink = Color(hex: "F06292")


### PR DESCRIPTION
## Jira
- [MG-9](https://ycompany.atlassian.net/browse/MG-9) (sub of [MG-5](https://ycompany.atlassian.net/browse/MG-5))

## Related
- 상위 PR: rrheon/Mongle `fix/MG-5-color-display-p3`
- 본 PR은 main 기반이라 MG-5와 독립 머지 가능

## Summary
iPhone 11 LCD에서 Material Green 500(`#4CAF50`) 류 값이 여전히 진하게 렌더링되는 하드웨어 재현 차이 대응.

- MongleFeatures Asset Catalog에 초록 Color Set 8종 추가 (Display P3 gamut, light/dark 분기)
  - `MonglePrimary`, `MonglePrimaryLight`, `MonglePrimaryDark`, `MonglePrimarySoft`
  - `MonglePrimaryGradientStart/End`, `MongleMonggleGreen`, `MongleSuccess`
- Color 값을 iPhone 15 Pro 파스텔 기준으로 하향
  - `#4CAF50` → `#8FD5A6`, `#388E3C` → `#5BAF85`, `#66BB6A` → `#8FD5A6` 등
- `DesignSystem.swift` 에서 해당 정적 프로퍼티를 `Color(name:bundle:)` + `Bundle.module`로 전환

## Test plan
- [x] iPhone 11 시뮬레이터에서 달력/캐릭터/HISTORY 탭 파스텔 복원 확인
- [x] iPhone 15 Pro에서 과도하게 연해지지 않았는지 확인
- [x] 다크 모드 전환 시 dark 값 자연스러운 매핑 확인
- [x] Monggle 캐릭터·상태 UI 가독성 확인

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)