### PR TITLE
fix(group): 그룹 전환 시 반드시 Home 탭으로 이동 (MG-13)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -534,6 +534,11 @@ extension RootFeature {
                     }
 
                 case .groupSelect(.delegate(.groupSelected(let family))):
+                    // MG-13: 그룹 전환 시 반드시 Home 탭으로 이동
+                    //   loadDataResponse 내부의 wasOnGroupSelect 체크는 .loading 으로 선전환되므로
+                    //   항상 false 가 되어 탭 리셋이 누락된다. 여기서 선제적으로 초기화한다.
+                    state.mainTab?.selectedTab = .home
+                    state.mainTab?.path.removeAll()
                     state.appState = .loading
                     return .run { [familyRepository] send in
                         do {


### PR DESCRIPTION
## Jira
- [MG-13](https://ycompany.atlassian.net/browse/MG-13)

## Summary
GroupSelectView에서 다른 그룹을 탭해도 이전 탭에 남아있던 버그 수정. groupSelected 핸들러에서 `.loading` 전환 **직전**에 `state.mainTab?.selectedTab = .home` + `state.mainTab?.path.removeAll()` 을 선제적으로 호출.

기존 `loadDataResponse` 내부의 `wasOnGroupSelect` 체크는 `.loading` 으로 선전환되어 항상 false 였음 — fallback 경로(초기 로그인)용으로만 유지.

## 변경
- `Root+Reducer.swift:537` groupSelected handler — 5줄 추가

## Test plan
- [x] 프로필 탭 → 그룹 선택 → 다른 그룹 탭 → Home 진입 확인
- [x] 히스토리 탭 → 동일 시나리오 확인
- [x] 질문 상세(path 깊음) → 그룹 전환 → path 리셋 + Home 진입
- [x] 최초 로그인(가족 없음) → 그룹 선택 → Home 진입 회귀

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)