### PR TITLE
fix(root): 그룹 진입 실패 시 무한로딩 방지 (MG-14)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -275,10 +275,22 @@ extension RootFeature {
                     if appError.requiresLogin {
                         return .send(.showLoginScreen)
                     }
+                    // 실패 시 대기 중이던 푸시 딥링크도 정리 — 다음 refresh 에 의도치 않게
+                    // 오래된 질문 화면이 열리는 것을 막는다.
+                    state.pendingOpenQuestion = false
                     if state.mainTab != nil {
                         state.mainTab?.home.isLoading = false
                         state.mainTab?.home.isRefreshing = false
                         state.mainTab?.home.appError = appError
+                        // 무한로딩 방지:
+                        //   .groupSelected 델리게이트는 appState 를 .loading 으로 선전환한 뒤
+                        //   selectFamily/refreshHomeData 를 실행한다. 이 체인이 실패하면 기존엔
+                        //   appState 가 .loading 으로 남아 LoadingView 가 계속 표시됐다.
+                        //   mainTab 이 이미 있으므로 복귀 위치를 (그룹 여부에 따라) 결정한다.
+                        if state.appState == .loading {
+                            let hasFamily = state.mainTab?.home.family != nil
+                            state.appState = hasFamily ? .authenticated : .groupSelection
+                        }
                     } else {
                         state.appState = .unauthenticated
                     }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -31,8 +31,9 @@ extension RootFeature {
                     }
 
                 case .refreshHomeData:
-                    return .run { send in
+                    return .run { [authRepository, familyRepository, questionRepository, answerRepository, userRepository, notificationRepository] send in
                         do {
+                            let data = try await Self.withTimeout(10) { () -> RootData in
                             // 최신 사용자 정보 조회 (닉네임 변경 등 반영)
                             let currentUser = try? await authRepository.getCurrentUser()
                             let familyResult = try await familyRepository.getMyFamily()
@@ -108,7 +109,7 @@ extension RootFeature {
                                 !$0.isRead && $0.familyId == currentFamilyId
                             }
 
-                            let data = RootData(
+                            return RootData(
                                 user: currentUser,
                                 question: todayQuestion,
                                 yesterdayQuestion: yesterdayQuestion,
@@ -123,6 +124,7 @@ extension RootFeature {
                                 allFamilies: allFamilies,
                                 hasUnreadNotifications: hasUnreadNotifications
                             )
+                            }
                             await send(.loadDataResponse(.success(data)))
                         } catch {
                             await send(.loadDataResponse(.failure(error)))
@@ -554,7 +556,10 @@ extension RootFeature {
                     state.appState = .loading
                     return .run { [familyRepository] send in
                         do {
-                            _ = try await familyRepository.selectFamily(familyId: family.id)
+                            // MG-14: 네트워크 불안정 시 selectFamily 가 무한 대기하지 않도록 10초 타임아웃.
+                            try await Self.withTimeout(10) {
+                                _ = try await familyRepository.selectFamily(familyId: family.id)
+                            }
                             await send(.refreshHomeData)
                         } catch {
                             await send(.loadDataResponse(.failure(error)))
@@ -687,6 +692,30 @@ extension RootFeature {
 
         .ifLet(\.$questionDetail, action: \.questionDetail) {
             QuestionDetailFeature()
+        }
+    }
+
+    // MARK: - Timeout Helper
+
+    /// 그룹 진입·홈 리프레시 경로가 네트워크 불안정으로 무한 대기되지 않도록
+    /// 전체 작업을 `seconds` 후 `URLError(.timedOut)` 로 실패시킨다.
+    ///
+    /// `URLSessionConfiguration.timeoutIntervalForRequest` 가 15초지만
+    /// `refreshHomeData` 는 최대 7개의 API 호출을 순차 실행하므로 최악의
+    /// 경우 100초 이상 hang 할 수 있다. 리듀서 단에서 10초로 잘라 UX 를
+    /// 확보한다.
+    static func withTimeout<T: Sendable>(
+        _ seconds: Double,
+        _ work: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await work() }
+            group.addTask { () async throws -> T in
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw URLError(.timedOut)
+            }
+            defer { group.cancelAll() }
+            return try await group.next()!
         }
     }
 

--- a/MongleFeatures/Tests/MongleFeaturesTests/RootFeatureTests.swift
+++ b/MongleFeatures/Tests/MongleFeaturesTests/RootFeatureTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+import ComposableArchitecture
+import Domain
+@testable import MongleFeatures
+
+/// MG-14 회귀 방지 — 그룹 진입 실패 경로에서 `appState` 가 `.loading` 으로 고착돼
+/// `LoadingView` 가 무한히 표시되던 문제를 검증한다.
+@MainActor
+final class RootFeatureTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// TestStore 에 최소한의 dependency 를 주입한다. 실패 핸들러는 repo 를 직접 호출하지
+    /// 않지만, TCA 가 reducer 바디를 구성할 때 `@Dependency` 접근이 발생할 수 있어
+    /// 방어적으로 testValue 를 세팅한다.
+    private func makeStore(initial: RootFeature.State) -> TestStore<RootFeature.State, RootFeature.Action> {
+        TestStore(initialState: initial) {
+            RootFeature()
+        } withDependencies: {
+            $0.notificationRepository = MockNotificationRepository()
+        }
+    }
+
+    private func stateWithMainTab(
+        family: MongleGroup?,
+        appState: RootFeature.State.AppState,
+        pendingOpenQuestion: Bool = false
+    ) -> RootFeature.State {
+        var s = RootFeature.State(appState: appState)
+        s.mainTab = MainTabFeature.State(
+            home: HomeFeature.State(family: family)
+        )
+        s.pendingOpenQuestion = pendingOpenQuestion
+        return s
+    }
+
+    // MARK: - MG-14: 무한로딩 방지
+
+    /// 그룹 진입 중(appState == .loading) 네트워크 실패가 발생해도,
+    /// mainTab 과 이전 가족이 있으면 `.authenticated` 로 복귀해야 한다.
+    func testLoadDataFailure_WhileLoadingWithFamily_RecoversToAuthenticated() async {
+        let family = GroupFactory.make()
+        let initial = stateWithMainTab(family: family, appState: .loading)
+        let store = makeStore(initial: initial)
+
+        let err = URLError(.notConnectedToInternet)
+        await store.send(.loadDataResponse(.failure(err))) {
+            $0.appState = .authenticated
+            $0.mainTab?.home.isLoading = false
+            $0.mainTab?.home.isRefreshing = false
+            $0.mainTab?.home.appError = .offline
+        }
+    }
+
+    /// 가족이 한 번도 없던 사용자(가족 탈퇴 직후 등)가 실패한 경우에는
+    /// `.groupSelection` 으로 복귀한다.
+    func testLoadDataFailure_WhileLoadingWithoutFamily_RecoversToGroupSelection() async {
+        let initial = stateWithMainTab(family: nil, appState: .loading)
+        let store = makeStore(initial: initial)
+
+        let err = URLError(.notConnectedToInternet)
+        await store.send(.loadDataResponse(.failure(err))) {
+            $0.appState = .groupSelection
+            $0.mainTab?.home.isLoading = false
+            $0.mainTab?.home.isRefreshing = false
+            $0.mainTab?.home.appError = .offline
+        }
+    }
+
+    /// 실패 시 `pendingOpenQuestion` 플래그가 정리돼 다음 refresh 에서
+    /// 오래된 푸시 딥링크가 의도치 않게 열리지 않아야 한다.
+    func testLoadDataFailure_ClearsPendingOpenQuestion() async {
+        let family = GroupFactory.make()
+        var initial = stateWithMainTab(family: family, appState: .authenticated)
+        initial.pendingOpenQuestion = true
+        let store = makeStore(initial: initial)
+
+        let err = URLError(.timedOut)
+        await store.send(.loadDataResponse(.failure(err))) {
+            $0.pendingOpenQuestion = false
+            $0.mainTab?.home.isLoading = false
+            $0.mainTab?.home.isRefreshing = false
+            $0.mainTab?.home.appError = .timeout
+        }
+    }
+
+    /// 기존 동작 보존 — mainTab 이 nil 이면 `.unauthenticated` 로 폴백한다.
+    func testLoadDataFailure_NoMainTab_FallsBackToUnauthenticated() async {
+        let initial = RootFeature.State(appState: .loading)
+        let store = makeStore(initial: initial)
+
+        let err = URLError(.notConnectedToInternet)
+        await store.send(.loadDataResponse(.failure(err))) {
+            $0.appState = .unauthenticated
+        }
+    }
+}


### PR DESCRIPTION
## Jira
- [MG-14](https://ycompany.atlassian.net/browse/MG-14)

## Summary
- `RootFeature` 의 `.loadDataResponse(.failure)` 에서 `appState` 가 `.loading` 으로 굳어버리던 경로를 보완
- `mainTab != nil` 이면 이전 가족 유무에 따라 `.authenticated` / `.groupSelection` 으로 복귀
- 실패 시 `pendingOpenQuestion` 플래그도 정리 — 다음 refresh 에서 오래된 푸시 딥링크가 열리지 않도록

## Test plan
- [x] 비행기 모드에서 그룹 카드 탭 → 이전 Home 으로 복귀 + 에러 토스트 노출
- [x] 비행기 해제 → Pull-to-refresh 로 정상 진입
- [x] 알림 목록에서 ANSWER_REQUEST / ANSWERER_NUDGE 탭 → 해당 그룹 Home 진입 정상
- [x] 정상 네트워크에서 그룹 선택 → Home 진입 회귀 없음

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)