### PR TITLE
fix(notification): REMINDER 타입 추가 — 7시 리마인더 수신·리스트·라우팅 대응 (MG-19)

### DIFF
--- a/Domain/Sources/Domain/Entities/Notification.swift
+++ b/Domain/Sources/Domain/Entities/Notification.swift
@@ -50,4 +50,5 @@ public enum NotificationType: Sendable, Equatable {
     case allAnswered     // 모든 구성원이 답변 완료했을 때
     case answerRequest   // 누군가 나에게 답변 요청할 때
     case badgeEarned
+    case reminder        // 저녁 7시 미답변자 리마인더 (MG-19)
 }

--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -50,7 +50,9 @@ class MongleAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         let userInfo = response.notification.request.content.userInfo
         if let type = userInfo["type"] as? String {
             switch type {
-            case "ANSWER_REQUEST", "MEMBER_ANSWERED", "NEW_QUESTION":
+            case "ANSWER_REQUEST", "MEMBER_ANSWERED", "NEW_QUESTION", "REMINDER":
+                // REMINDER는 홈으로 보내 오늘의 질문 카드를 즉시 노출.
+                // (답변자는 재촉하기 버튼, 미답변자는 답변 작성 CTA로 자연스럽게 유도.)
                 store?.send(.openQuestion)
             default:
                 break

--- a/MongleData/Sources/MongleData/Repositories/NotificationRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/NotificationRepository.swift
@@ -79,6 +79,7 @@ private struct NotificationDTO: Decodable {
         case "ALL_ANSWERED": return .allAnswered
         case "ANSWER_REQUEST": return .answerRequest
         case "BADGE_EARNED": return .badgeEarned
+        case "REMINDER": return .reminder
         default: return nil
         }
     }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationView.swift
@@ -227,6 +227,8 @@ private struct NotificationCard: View {
             return "bell.badge.fill"
         case .badgeEarned:
             return "gift.fill"
+        case .reminder:
+            return "clock.badge.fill"
         }
     }
 
@@ -242,6 +244,8 @@ private struct NotificationCard: View {
             return MongleColor.accentOrange
         case .badgeEarned:
             return MongleColor.moodLoved
+        case .reminder:
+            return MongleColor.accentOrange
         }
     }
 
@@ -257,6 +261,8 @@ private struct NotificationCard: View {
             return MongleColor.bgWarmLight
         case .badgeEarned:
             return MongleColor.bgErrorLight
+        case .reminder:
+            return MongleColor.bgWarmLight
         }
     }
 


### PR DESCRIPTION
## Jira
- [MG-19](https://ycompany.atlassian.net/browse/MG-19)

## Related
- 서버 PR: rrheon/Mongle-Server (별도 브랜치 진행 중)
- Android PR: rrheon/Mongle-Android (별도 브랜치 진행 중)

## Summary
서버가 저녁 7시 미답변자 리마인더 푸시(`type: "REMINDER"`)를 정상 발송해도 iOS가 해당 타입을 **완전히 인식하지 못해** in-app 알림 리스트에서 누락되고, 탭해도 라우팅되지 않던 문제를 4곳 수정으로 해결.

- `Domain/Notification.swift` — `NotificationType` enum에 `.reminder` case 추가
- `NotificationRepository.swift` — `mapType("REMINDER") → .reminder` 매핑
- `MongleApp.swift` — `didReceive()` switch에 `REMINDER` 분기 추가 (홈으로 라우팅)
- `NotificationView.swift` — 아이콘(`clock.badge.fill`)·틴트·배경 3개 switch에 `.reminder` case

## Test plan
- [x] TestFlight 빌드에서 서버가 `type: "REMINDER"` payload 발송 시 포그라운드 배너·사운드 표시
- [x] 알림 리스트(`NotificationView`)에 리마인더 항목 노출 + 아이콘 `clock.badge.fill` 확인
- [x] 리스트 탭 시 홈으로 이동해 오늘의 질문 카드 노출
- [x] 기존 재촉/답변완료/새 질문/전원 답변/배지 알림 회귀 없음

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)