### PR TITLE
Release v2: MG-19 7시 미답변자 리마인더 REMINDER 타입 통합

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ GoogleService-Info.plist
 *.env
 Secrets.swift
 **/Secrets.swift
+*.p8
+AuthKey_*.p8
 
 # 로컬 전용 — 디자인/미디어/참고 자료
 *.pen

--- a/Domain/Sources/Domain/Entities/Notification.swift
+++ b/Domain/Sources/Domain/Entities/Notification.swift
@@ -50,4 +50,5 @@ public enum NotificationType: Sendable, Equatable {
     case allAnswered     // 모든 구성원이 답변 완료했을 때
     case answerRequest   // 누군가 나에게 답변 요청할 때
     case badgeEarned
+    case reminder        // 저녁 7시 미답변자 리마인더 (MG-19)
 }

--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -50,7 +50,9 @@ class MongleAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         let userInfo = response.notification.request.content.userInfo
         if let type = userInfo["type"] as? String {
             switch type {
-            case "ANSWER_REQUEST", "MEMBER_ANSWERED", "NEW_QUESTION":
+            case "ANSWER_REQUEST", "MEMBER_ANSWERED", "NEW_QUESTION", "REMINDER":
+                // REMINDER는 홈으로 보내 오늘의 질문 카드를 즉시 노출.
+                // (답변자는 재촉하기 버튼, 미답변자는 답변 작성 CTA로 자연스럽게 유도.)
                 store?.send(.openQuestion)
             default:
                 break

--- a/MongleData/Sources/MongleData/Repositories/NotificationRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/NotificationRepository.swift
@@ -79,6 +79,7 @@ private struct NotificationDTO: Decodable {
         case "ALL_ANSWERED": return .allAnswered
         case "ANSWER_REQUEST": return .answerRequest
         case "BADGE_EARNED": return .badgeEarned
+        case "REMINDER": return .reminder
         default: return nil
         }
     }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationView.swift
@@ -227,6 +227,8 @@ private struct NotificationCard: View {
             return "bell.badge.fill"
         case .badgeEarned:
             return "gift.fill"
+        case .reminder:
+            return "clock.badge.fill"
         }
     }
 
@@ -242,6 +244,8 @@ private struct NotificationCard: View {
             return MongleColor.accentOrange
         case .badgeEarned:
             return MongleColor.moodLoved
+        case .reminder:
+            return MongleColor.accentOrange
         }
     }
 
@@ -257,6 +261,8 @@ private struct NotificationCard: View {
             return MongleColor.bgWarmLight
         case .badgeEarned:
             return MongleColor.bgErrorLight
+        case .reminder:
+            return MongleColor.bgWarmLight
         }
     }
 


### PR DESCRIPTION
## Jira
- [MG-19](https://ycompany.atlassian.net/browse/MG-19)

## Summary
v2 릴리스 — develop 브랜치에 누적된 MG-19 (REMINDER 알림 타입) 수정을 main으로 병합.

서버는 이미 prod 배포 완료되어 KST 19:00 cron으로 REMINDER 푸시 발송 중.
iOS 클라이언트가 REMINDER 타입을 인식하도록 4곳 수정(PR #34)을 포함.

## 포함 변경
- fix(notification): REMINDER 타입 추가 — 수신·리스트·라우팅 대응 (MG-19)
  - `Domain/.../Notification.swift` — NotificationType.reminder case
  - `MongleData/.../NotificationRepository.swift` — mapType("REMINDER") → .reminder
  - `Mongle/MongleApp.swift` — didReceive REMINDER 분기 (홈 라우팅)
  - `MongleFeatures/.../NotificationView.swift` — clock.badge.fill + warm 틴트
- chore(gitignore): APNs AuthKey(.p8) 제외

## Release Checklist
- [ ] main 머지 완료 후 iOS 빌드 번호 증가
- [ ] Archive → App Store Connect 업로드 → TestFlight
- [ ] 본인 기기 TestFlight 업그레이드 후 KST 19:00 cron 또는 수동 invoke로 검증
- [ ] 답변자 / 미답변자 양쪽 메시지 정상 수신 + 앱 내 알림 리스트 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)