### PR TITLE
[MG-27] 계정 탈퇴·그룹 나가기 2차 확인 팝업 추가

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectFeature.swift
@@ -77,6 +77,7 @@ public struct GroupSelectFeature {
         public var currentUserId: UUID? = nil
         public var groupToLeave: MongleGroup? = nil
         public var showLeaveConfirmation: Bool = false
+        public var showLeaveFinalConfirmation: Bool = false
         public var showLeaveTooSoonToast: Bool = false   // 72시간(3일) 미경과 안내 토스트
         public var leaveTooSoonMessage: String = ""
         public var transferCandidates: [User] = []
@@ -133,6 +134,8 @@ public struct GroupSelectFeature {
 
         // MARK: - 그룹 나가기
         case leaveGroupTapped(MongleGroup)
+        case firstConfirmLeave
+        case cancelLeaveFinalConfirmation
         case confirmLeave
         case cancelLeaveConfirmation
         case dismissLeaveTooSoonToast
@@ -444,14 +447,25 @@ public struct GroupSelectFeature {
                 state.showLeaveTooSoonToast = false
                 return .none
 
+            case .firstConfirmLeave:
+                state.showLeaveConfirmation = false
+                state.showLeaveFinalConfirmation = true
+                return .none
+
+            case .cancelLeaveFinalConfirmation:
+                state.showLeaveFinalConfirmation = false
+                return .none
+
             case .confirmLeave:
                 state.showLeaveConfirmation = false
+                state.showLeaveFinalConfirmation = false
                 guard let group = state.groupToLeave else { return .none }
                 state.isProcessingLeave = true
                 return .send(.delegate(.leaveGroup(group)))
 
             case .cancelLeaveConfirmation:
                 state.showLeaveConfirmation = false
+                state.showLeaveFinalConfirmation = false
                 state.groupToLeave = nil
                 return .none
 

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectView+Select.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectView+Select.swift
@@ -109,11 +109,24 @@ extension GroupSelectView {
           primaryLabel: L10n.tr("group_leave_btn"),
           secondaryLabel: L10n.tr("common_cancel"),
           isDestructive: true,
-          onPrimary: { store.send(.confirmLeave) },
+          onPrimary: { store.send(.firstConfirmLeave) },
           onSecondary: { store.send(.cancelLeaveConfirmation) }
         )
         .transition(.opacity)
         .animation(.easeInOut(duration: 0.2), value: store.showLeaveConfirmation)
+      }
+      if store.showLeaveFinalConfirmation {
+        MonglePopupView(
+          title: L10n.tr("group_leave_final_title"),
+          description: L10n.tr("group_leave_final_desc"),
+          primaryLabel: L10n.tr("group_leave_final_confirm"),
+          secondaryLabel: L10n.tr("group_leave_final_cancel"),
+          isDestructive: true,
+          onPrimary: { store.send(.confirmLeave) },
+          onSecondary: { store.send(.cancelLeaveFinalConfirmation) }
+        )
+        .transition(.opacity)
+        .animation(.easeInOut(duration: 0.2), value: store.showLeaveFinalConfirmation)
       }
     }
     .navigationDestination(isPresented: Binding(

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/AccountManagementFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/AccountManagementFeature.swift
@@ -6,6 +6,7 @@ public struct AccountManagementFeature {
     public struct State: Equatable {
         public var showLogoutConfirm = false
         public var showDeleteConfirm = false
+        public var showDeleteFinalConfirm = false
         public var isLoading = false
         public var errorMessage: String? = nil
         public var appError: AppError? = nil
@@ -18,6 +19,8 @@ public struct AccountManagementFeature {
         case logoutTapped
         case logoutConfirmed
         case deleteAccountTapped
+        case deleteAccountFirstConfirmed
+        case deleteAccountFinalCancelled
         case deleteAccountConfirmed
         case alertDismissed
         case setLoading(Bool)
@@ -63,8 +66,18 @@ public struct AccountManagementFeature {
                 state.showDeleteConfirm = true
                 return .none
 
+            case .deleteAccountFirstConfirmed:
+                state.showDeleteConfirm = false
+                state.showDeleteFinalConfirm = true
+                return .none
+
+            case .deleteAccountFinalCancelled:
+                state.showDeleteFinalConfirm = false
+                return .none
+
             case .deleteAccountConfirmed:
                 state.showDeleteConfirm = false
+                state.showDeleteFinalConfirm = false
                 state.isLoading = true
                 return .run { send in
                     do {
@@ -78,6 +91,7 @@ public struct AccountManagementFeature {
             case .alertDismissed:
                 state.showLogoutConfirm = false
                 state.showDeleteConfirm = false
+                state.showDeleteFinalConfirm = false
                 return .none
 
             case .setLoading(let loading):

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/AccountManagementView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/AccountManagementView.swift
@@ -47,11 +47,24 @@ public struct AccountManagementView: View {
                     primaryLabel: L10n.tr("settings_delete_btn"),
                     secondaryLabel: L10n.tr("common_cancel"),
                     isDestructive: true,
-                    onPrimary: { store.send(.deleteAccountConfirmed) },
+                    onPrimary: { store.send(.deleteAccountFirstConfirmed) },
                     onSecondary: { store.send(.alertDismissed) }
                 )
                 .transition(.opacity)
                 .animation(.easeInOut(duration: 0.2), value: store.showDeleteConfirm)
+            }
+            if store.showDeleteFinalConfirm {
+                MonglePopupView(
+                    title: L10n.tr("settings_delete_final_title"),
+                    description: L10n.tr("settings_delete_final_desc"),
+                    primaryLabel: L10n.tr("settings_delete_final_confirm"),
+                    secondaryLabel: L10n.tr("settings_delete_final_cancel"),
+                    isDestructive: true,
+                    onPrimary: { store.send(.deleteAccountConfirmed) },
+                    onSecondary: { store.send(.deleteAccountFinalCancelled) }
+                )
+                .transition(.opacity)
+                .animation(.easeInOut(duration: 0.2), value: store.showDeleteFinalConfirm)
             }
         }
     }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Settings/SettingsFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Settings/SettingsFeature.swift
@@ -24,6 +24,7 @@ public struct SettingsFeature {
         public var isLoading: Bool
         public var showLogoutConfirmation: Bool
         public var showDeleteAccountConfirmation: Bool
+        public var showDeleteAccountFinalConfirmation: Bool
         public var errorMessage: String?
         /// UMP(GDPR/CCPA) 대상 사용자에게만 "개인정보 옵션 다시 열기" 행을 노출한다.
         public var showPrivacyOptionsRow: Bool
@@ -36,6 +37,7 @@ public struct SettingsFeature {
             isLoading: Bool = false,
             showLogoutConfirmation: Bool = false,
             showDeleteAccountConfirmation: Bool = false,
+            showDeleteAccountFinalConfirmation: Bool = false,
             errorMessage: String? = nil,
             showPrivacyOptionsRow: Bool = false
         ) {
@@ -46,6 +48,7 @@ public struct SettingsFeature {
             self.isLoading = isLoading
             self.showLogoutConfirmation = showLogoutConfirmation
             self.showDeleteAccountConfirmation = showDeleteAccountConfirmation
+            self.showDeleteAccountFinalConfirmation = showDeleteAccountFinalConfirmation
             self.errorMessage = errorMessage
             self.showPrivacyOptionsRow = showPrivacyOptionsRow
         }
@@ -64,6 +67,8 @@ public struct SettingsFeature {
         case logoutConfirmed
         case logoutCancelled
         case deleteAccountTapped
+        case deleteAccountFirstConfirmed
+        case deleteAccountFinalCancelled
         case deleteAccountConfirmed
         case deleteAccountCancelled
         case dismissErrorTapped
@@ -158,10 +163,21 @@ public struct SettingsFeature {
 
             case .deleteAccountCancelled:
                 state.showDeleteAccountConfirmation = false
+                state.showDeleteAccountFinalConfirmation = false
+                return .none
+
+            case .deleteAccountFirstConfirmed:
+                state.showDeleteAccountConfirmation = false
+                state.showDeleteAccountFinalConfirmation = true
+                return .none
+
+            case .deleteAccountFinalCancelled:
+                state.showDeleteAccountFinalConfirmation = false
                 return .none
 
             case .deleteAccountConfirmed:
                 state.showDeleteAccountConfirmation = false
+                state.showDeleteAccountFinalConfirmation = false
                 state.isLoading = true
                 let providerType = state.loginProviderType
                 return .run { send in

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Settings/SettingsTabView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Settings/SettingsTabView.swift
@@ -75,11 +75,24 @@ struct SettingsTabView: View {
                         description: L10n.tr("settings_delete_confirm"),
                         primaryLabel: L10n.tr("settings_delete_btn"),
                         secondaryLabel: L10n.tr("common_cancel"),
-                        onPrimary: { store.send(.deleteAccountConfirmed) },
+                        onPrimary: { store.send(.deleteAccountFirstConfirmed) },
                         onSecondary: { store.send(.deleteAccountCancelled) }
                     )
                     .transition(.opacity)
                     .animation(.easeInOut(duration: 0.2), value: store.showDeleteAccountConfirmation)
+                }
+                if store.showDeleteAccountFinalConfirmation {
+                    MonglePopupView(
+                        title: L10n.tr("settings_delete_final_title"),
+                        description: L10n.tr("settings_delete_final_desc"),
+                        primaryLabel: L10n.tr("settings_delete_final_confirm"),
+                        secondaryLabel: L10n.tr("settings_delete_final_cancel"),
+                        isDestructive: true,
+                        onPrimary: { store.send(.deleteAccountConfirmed) },
+                        onSecondary: { store.send(.deleteAccountFinalCancelled) }
+                    )
+                    .transition(.opacity)
+                    .animation(.easeInOut(duration: 0.2), value: store.showDeleteAccountFinalConfirmation)
                 }
             }
         }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/GroupManagementFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/GroupManagementFeature.swift
@@ -31,6 +31,7 @@ public struct GroupManagementFeature {
         public var familyCreatedById: UUID?
         public var familyCreatedAt: Date?
         public var showLeaveConfirm: Bool = false
+        public var showLeaveFinalConfirm: Bool = false
         public var showLeaveTooSoonToast: Bool = false   // 72시간(3일) 미경과 안내 토스트
         public var leaveTooSoonMessage: String = ""
         public var isLeaving: Bool = false
@@ -64,6 +65,8 @@ public struct GroupManagementFeature {
         case inviteCodeCopyTapped
         case copiedToastDismissed
         case leaveGroupTapped
+        case leaveGroupFirstConfirmed
+        case leaveGroupFinalCancelled
         case leaveGroupConfirmed
         case leaveGroupAlertDismissed
         case leaveGroupFailure(AppError)
@@ -139,12 +142,23 @@ public struct GroupManagementFeature {
                 state.showLeaveConfirm = true
                 return .none
 
+            case .leaveGroupFirstConfirmed:
+                state.showLeaveConfirm = false
+                state.showLeaveFinalConfirm = true
+                return .none
+
+            case .leaveGroupFinalCancelled:
+                state.showLeaveFinalConfirm = false
+                return .none
+
             case .leaveGroupAlertDismissed:
                 state.showLeaveConfirm = false
+                state.showLeaveFinalConfirm = false
                 return .none
 
             case .leaveGroupConfirmed:
                 state.showLeaveConfirm = false
+                state.showLeaveFinalConfirm = false
                 if state.isCurrentUserOwner {
                     // 방장은 멤버 수와 무관하게 그룹 생성 후 72시간 이내 나가기 불가
                     // (위임 후 나가기로 빠져나가는 것도 차단 — GroupSelectFeature / Android 와 동일 정책)

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/GroupManagementView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/GroupManagementView.swift
@@ -39,11 +39,24 @@ public struct GroupManagementView: View {
           primaryLabel: L10n.tr("mgmt_leave_btn"),
           secondaryLabel: L10n.tr("common_cancel"),
           isDestructive: true,
-          onPrimary: { store.send(.leaveGroupConfirmed) },
+          onPrimary: { store.send(.leaveGroupFirstConfirmed) },
           onSecondary: { store.send(.leaveGroupAlertDismissed) }
         )
         .transition(.opacity)
         .animation(.easeInOut(duration: 0.2), value: store.showLeaveConfirm)
+      }
+      if store.showLeaveFinalConfirm {
+        MonglePopupView(
+          title: L10n.tr("group_leave_final_title"),
+          description: L10n.tr("group_leave_final_desc"),
+          primaryLabel: L10n.tr("group_leave_final_confirm"),
+          secondaryLabel: L10n.tr("group_leave_final_cancel"),
+          isDestructive: true,
+          onPrimary: { store.send(.leaveGroupConfirmed) },
+          onSecondary: { store.send(.leaveGroupFinalCancelled) }
+        )
+        .transition(.opacity)
+        .animation(.easeInOut(duration: 0.2), value: store.showLeaveFinalConfirm)
       }
     }
     .overlay {

--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -285,6 +285,10 @@
 "settings_delete_account_desc" = "All data will be deleted permanently";
 "settings_delete_confirm" = "All data will be deleted.\nThis cannot be undone.";
 "settings_delete_btn" = "Delete Account";
+"settings_delete_final_title" = "One last check";
+"settings_delete_final_desc" = "Are you sure you want to leave Mongle?\nThis choice cannot be undone.";
+"settings_delete_final_confirm" = "Yes, delete my account";
+"settings_delete_final_cancel" = "I'll think it over";
 "settings_login_required" = "Login Required";
 "settings_login_required_desc" = "Login required to use this feature.";
 "settings_login_btn" = "Log In";
@@ -297,6 +301,10 @@
 "mgmt_leave" = "Leave Group";
 "mgmt_leave_desc" = "Leaving disconnects all answer records.";
 "mgmt_leave_btn" = "Leave";
+"group_leave_final_title" = "Are you sure?";
+"group_leave_final_desc" = "Your daily moments with this family end here.\nYou'll need a new invite to return.";
+"group_leave_final_confirm" = "Yes, leave";
+"group_leave_final_cancel" = "I'll stay for now";
 "mgmt_kick" = "Remove %@?";
 "mgmt_kick_desc" = "This member will be removed.";
 "mgmt_kick_btn" = "Remove";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -285,6 +285,10 @@
 "settings_delete_account_desc" = "すべてのデータが削除され復元できません";
 "settings_delete_confirm" = "退会するとすべてのデータが削除されます。\nこの操作は元に戻せません。";
 "settings_delete_btn" = "退会する";
+"settings_delete_final_title" = "最終確認です";
+"settings_delete_final_desc" = "本当にMongleとお別れしますか？\nこの選択は取り消せません。";
+"settings_delete_final_confirm" = "はい、退会します";
+"settings_delete_final_cancel" = "もう少し考えます";
 "settings_login_required" = "ログインが必要です";
 "settings_login_required_desc" = "この機能を利用するにはログインが必要です。";
 "settings_login_btn" = "ログインする";
@@ -297,6 +301,10 @@
 "mgmt_leave" = "グループを退出";
 "mgmt_leave_desc" = "グループを退出すると全ての回答記録の接続が解除されます。";
 "mgmt_leave_btn" = "退出する";
+"group_leave_final_title" = "本当に退出しますか？";
+"group_leave_final_desc" = "この家族との毎日がここで途切れるかもしれません。\n戻るには再度招待が必要です。";
+"group_leave_final_confirm" = "はい、退出します";
+"group_leave_final_cancel" = "もう少しいます";
 "mgmt_kick" = "%@さんを退出させますか？";
 "mgmt_kick_desc" = "このメンバーはグループから除外されます。";
 "mgmt_kick_btn" = "退出させる";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -285,6 +285,10 @@
 "settings_delete_account_desc" = "모든 데이터가 삭제되며 복구할 수 없어요";
 "settings_delete_confirm" = "탈퇴하면 모든 데이터가 삭제돼요.\n이 작업은 되돌릴 수 없어요.";
 "settings_delete_btn" = "탈퇴하기";
+"settings_delete_final_title" = "마지막 확인이에요";
+"settings_delete_final_desc" = "정말 몽글과 작별하실 건가요?\n이 선택은 취소할 수 없어요.";
+"settings_delete_final_confirm" = "네, 탈퇴할게요";
+"settings_delete_final_cancel" = "더 생각해볼게요";
 "settings_login_required" = "로그인이 필요해요";
 "settings_login_required_desc" = "이 기능을 이용하려면 로그인이 필요해요.";
 "settings_login_btn" = "로그인하기";
@@ -297,6 +301,10 @@
 "mgmt_leave" = "그룹 나가기";
 "mgmt_leave_desc" = "그룹을 나가면 모든 멤버와의 답변 기록이 연결 해제됩니다.";
 "mgmt_leave_btn" = "나가기";
+"group_leave_final_title" = "정말 나가실 건가요?";
+"group_leave_final_desc" = "이 가족과의 하루하루가 여기서 끊길 수 있어요.\n돌아오려면 다시 초대받아야 해요.";
+"group_leave_final_confirm" = "네, 나갈게요";
+"group_leave_final_cancel" = "더 있어볼게요";
 "mgmt_kick" = "%@님을 내보낼까요?";
 "mgmt_kick_desc" = "해당 멤버는 그룹에서 제외됩니다.";
 "mgmt_kick_btn" = "내보내기";


### PR DESCRIPTION
## Jira
- [MG-27](https://ycompany.atlassian.net/browse/MG-27)
- 상위: [MG-24 팝업 UX 개선 Epic](https://ycompany.atlassian.net/browse/MG-24)

## Related
- MG-25 (iOS 팝업 문구 전수 개선) — 1차 팝업 문구는 그 티켓에서 일괄 개선 예정
- MG-28 (Android 동일 UX 적용) — 차기 착수

## Summary
- 계정 탈퇴·그룹 나가기의 1차 확인 팝업에서 즉시 실행되던 것을 **2단계 확인 UX(Context-aware, 플로우 C)**로 변경
- 1차: 실손실 명시(기존 문구 유지)  →  2차: 감성 최종 확인
- 적용 범위 4곳: AccountManagement / Settings(탭) / GroupManagement / GroupSelect(context menu)
- TCA 패턴 유지. 기존 `*Confirmed` 액션의 실제 로직은 그대로. 1차 onPrimary만 `*FirstConfirmed`로 교체
- Localizable.strings ko/en/ja 신규 키 8개 추가

## Test plan
- [ ] 계정 관리 → 탈퇴 → 1차 [탈퇴하기] → 2차 팝업 표시 → [네, 탈퇴할게요]로 실제 탈퇴
- [ ] 2차에서 [더 생각해볼게요] → 1차·2차 모두 닫히고 원상 복귀
- [ ] 설정 탭에서 동일 플로우 확인
- [ ] 그룹 관리/그룹 선택 menu에서 동일 플로우 확인
- [ ] 방장 72시간 미경과 시 기존 toast 동작 유지 (2차 팝업으로 빠지지 않는지)
- [ ] 로그아웃은 기존 1단계 확인 유지
- [ ] 라이트·다크 모드 모두 확인
- [ ] ko / en / ja 로케일 문구 확인

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)