### PR TITLE
fix(group): 초대코드 화면 자동 이탈 방지 (MG-31)

### DIFF
--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -36,9 +36,13 @@ class MongleAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         completionHandler([.banner, .sound, .badge])
-        // 포그라운드에서 푸시가 도착한 경우, 홈/그룹선택 화면의 우상단 빨간 점이
-        // 즉시 반영되도록 데이터 리프레시를 트리거한다.
-        store?.send(.refreshHomeData)
+        // 포그라운드 push 가 도착했을 때 홈 배지 갱신은 authenticated 상태에서만 의미가 있다.
+        // 그룹 선택/초대코드/로그인/동의 화면 중에는 refreshHomeData 가 loadDataResponse 를
+        // 통해 appState 를 강제로 .authenticated 로 전환해 현재 화면을 덮어쓰므로 발송 금지.
+        // (RootView 의 scenePhase 핸들러 가드와 동일한 규칙)
+        if store?.state.appState == .authenticated {
+            store?.send(.refreshHomeData)
+        }
     }
 
     /// 알림 탭 처리

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectFeature.swift
@@ -262,6 +262,15 @@ public struct GroupSelectFeature {
                 return .none
 
             case .completeTapped:
+                // step 을 리셋해야 Root.loadDataResponse 의 invite-화면-유지 가드
+                // (preserveInviteCodeScreen) 가 .completed 로 트리거된 정상 refresh 를
+                // 막지 않는다. 동시에 초대코드/폼 상태도 함께 비움.
+                state.step = .select
+                state.inviteCode = ""
+                state.groupName = ""
+                state.nickname = ""
+                state.selectedColorId = "loved"
+                state.isColorExplicitlySelected = false
                 return .send(.delegate(.completed))
 
             case .joinBackTapped:
@@ -314,7 +323,13 @@ public struct GroupSelectFeature {
                 return .none
 
             case .setJoinSuccess:
+                // completeTapped 와 마찬가지로 다음 방문 시 이전 입력이 남지 않도록 폼을 리셋.
                 state.isLoading = false
+                state.step = .select
+                state.joinCode = ""
+                state.nickname = ""
+                state.selectedColorId = "loved"
+                state.isColorExplicitlySelected = false
                 return .send(.delegate(.completed))
 
             case .notificationPermissionAllowed:

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -229,7 +229,15 @@ extension RootFeature {
                         )
                     }
                     let wasOnGroupSelect = state.appState == .groupSelection
-                    let newAppState: RootFeature.State.AppState = (data.family == nil || isInitialLoad) ? .groupSelection : .authenticated
+                    // 초대코드 화면(step=.groupCreated) 에 머무는 동안엔 refreshHomeData 가
+                    // 어디서 트리거되든 (예: 가족 생성 직후 서버가 NEW_QUESTION 을
+                    // assignQuestionToFamily → APNs 로 발송 → foreground willPresent 가
+                    // refreshHomeData 호출) authenticated 로 강제 전환하지 않는다.
+                    // 사용자가 "홈으로" 를 눌러 step 이 .select 로 리셋된 뒤에만 전환된다.
+                    let preserveInviteCodeScreen = wasOnGroupSelect && state.groupSelect.step == .groupCreated
+                    let newAppState: RootFeature.State.AppState = preserveInviteCodeScreen
+                        ? .groupSelection
+                        : ((data.family == nil || isInitialLoad) ? .groupSelection : .authenticated)
                     // 그룹 선택 화면에서 인증 완료 전환 시 HomeTab으로 리셋
                     if wasOnGroupSelect && newAppState == .authenticated {
                         state.mainTab?.selectedTab = .home


### PR DESCRIPTION
## Jira
- [MG-31](https://ycompany.atlassian.net/browse/MG-31)

## Related
- MG-16 — 가족 생성 직후 첫 질문 즉시 발급(서버 트리거, 변경 없음)
- MG-13 — 그룹 전환 시 Home 탭 리셋 (동일 `loadDataResponse` 인접 영역)

## Summary
- 새 가족 생성 후 초대코드 화면이 사용자의 "홈으로" 탭 전에 자동으로 홈으로 이탈하던 버그 수정.
- 근본 트리거는 서버의 NEW_QUESTION APNs (MG-16) 를 foreground 수신한 `willPresent` 가 `appState` 와 무관하게 `refreshHomeData` 를 dispatch하고, `loadDataResponse` 가 `.authenticated` 로 강제 전환하던 것.
- Defense-in-depth 로 3곳 수정:
  1. `MongleApp.willPresent` — `appState == .authenticated` 에서만 refresh (scenePhase 핸들러와 동일 규칙).
  2. `Root.loadDataResponse` — `step == .groupCreated` 동안 `.groupSelection` 유지(`preserveInviteCodeScreen`).
  3. `GroupSelectFeature.completeTapped` / `setJoinSuccess` — 사용자 명시 완료 시 step 과 폼 필드 리셋.

## Test plan
- [ ] 신규 유저 최초 가족 생성 → 초대코드 화면 "홈으로" 탭 전까지 유지 (골든 패스)
- [ ] 초대코드/링크 복사, ShareLink 공유 중 자동 이탈 없음
- [ ] "홈으로" 탭 → MainTab(Home) + `selectedTab=.home`
- [ ] 2·3번째 가족 생성 시 동일 보장
- [ ] 기존 초대코드로 참여 플로우 회귀 없음
- [ ] 설정 → 새 그룹 만들기(navigateToGroupSelect) 경로도 동일
- [ ] 홈 진입 후 포그라운드 푸시 수신 시 알림 배지 갱신 정상(`.authenticated` 에서는 refresh 유지)
- [ ] `MongleFeaturesTests/GroupSelectFeatureTests` 19건 통과 (pre-existing 2건 실패는 `onAppear.isLoadingGroups`, 무관)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)