### PR TITLE
[MG-32] 딥링크 하트 누락 + 동명 그룹 다중선택 UI 수정

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Home/HomeView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Home/HomeView.swift
@@ -13,6 +13,7 @@ import Domain
 struct HomeTopBarState {
   var streakDays: Int
   var groupName: String
+  var groupId: UUID?
   var hasNotification: Bool
   var hearts: Int
   var todayQuestion: TopBarQuestion?
@@ -21,6 +22,7 @@ struct HomeTopBarState {
   init(
     streakDays: Int,
     groupName: String,
+    groupId: UUID? = nil,
     hasNotification: Bool,
     hearts: Int,
     todayQuestion: TopBarQuestion? = nil,
@@ -28,6 +30,7 @@ struct HomeTopBarState {
   ) {
     self.streakDays = streakDays
     self.groupName = groupName
+    self.groupId = groupId
     self.hasNotification = hasNotification
     self.hearts = hearts
     self.todayQuestion = todayQuestion
@@ -141,7 +144,7 @@ struct HomeView: View {
 
                 GroupDropdownView(
                     families: topBarState.allFamilies,
-                    currentGroupName: topBarState.groupName,
+                    currentGroupId: topBarState.groupId,
                     onGroupSelected: { family in
                         withAnimation(.easeInOut(duration: 0.15)) { showGroupDropdown = false }
                         actions.onGroupSelected(family)
@@ -403,7 +406,7 @@ private struct TodayQuestionCard: View {
 
 private struct GroupDropdownView: View {
   let families: [MongleGroup]
-  let currentGroupName: String
+  let currentGroupId: UUID?
   var onGroupSelected: (MongleGroup) -> Void
   var onNavigateToGroupSelect: () -> Void
 
@@ -419,12 +422,12 @@ private struct GroupDropdownView: View {
               Text(family.name)
                 .font(MongleFont.body1())
                 .foregroundColor(
-                  family.name == currentGroupName
+                  family.id == currentGroupId
                     ? MongleColor.primary
                     : MongleColor.textPrimary
                 )
               Spacer()
-              if family.name == currentGroupName {
+              if family.id == currentGroupId {
                 Image(systemName: "checkmark")
                   .font(.system(size: 13, weight: .semibold))
                   .foregroundColor(MongleColor.primary)

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
@@ -164,6 +164,7 @@ struct MainTabView: View {
             topBarState: HomeTopBarState(
                 streakDays: store.home.streakDays,
                 groupName: store.home.family?.name ?? L10n.tr("home_default_group"),
+                groupId: store.home.family?.id,
                 hasNotification: store.home.hasUnreadNotifications,
                 hearts: store.home.hearts,
                 todayQuestion: store.home.todayQuestion.map {

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -244,7 +244,8 @@ extension RootFeature {
                             state.mainTab?.path.append(.questionDetail(QuestionDetailFeature.State(
                                 question: question,
                                 currentUser: data.user,
-                                familyMembers: data.familyMembers
+                                familyMembers: data.familyMembers,
+                                hearts: data.user?.hearts ?? 0
                             )))
                         }
                         return .run { _ in
@@ -667,11 +668,13 @@ extension RootFeature {
                        state.appState == .authenticated {
                         let currentUser = state.mainTab?.home.currentUser
                         let familyMembers = state.mainTab?.home.familyMembers ?? []
+                        let hearts = state.mainTab?.home.hearts ?? 0
                         state.mainTab?.path.removeAll()
                         state.mainTab?.path.append(.questionDetail(QuestionDetailFeature.State(
                             question: question,
                             currentUser: currentUser,
-                            familyMembers: familyMembers
+                            familyMembers: familyMembers,
+                            hearts: hearts
                         )))
                     } else {
                         // 아직 데이터 로딩 중 → 로딩 완료 후 이동


### PR DESCRIPTION
## Jira
- [MG-32](https://ycompany.atlassian.net/browse/MG-32)

## Summary
두 건의 독립된 UI 오동작을 한 번에 수정합니다.

**1. 하트 충분한데 수정 차단**
- `QuestionDetailFeature.State.hearts` 기본값 0이 원인. `Root+Reducer.swift`의 푸시 콜드 스타트(pendingOpenQuestion)와 딥링크(openQuestion) 두 init 사이트에서 `hearts:` 인자 누락 → 답변 수정 팝업의 `hasEnoughHearts`가 항상 false.
- MainTab 경유 4개 사이트는 이미 `state.home.hearts`를 정상 전달 → Home 탭을 거쳐 들어가면 정상, 푸시/딥링크로 들어가면 수정 불가라는 경로 의존 증상.
- Fix: 두 init 사이트에 `hearts: data.user?.hearts ?? 0` / `hearts: state.mainTab?.home.hearts ?? 0` 추가.

**2. 동명 그룹 다중선택 표시**
- `GroupDropdownView`가 선택 강조를 `family.name == currentGroupName`으로 비교. 같은 이름 그룹이 2개 이상이면 모두 체크 표시됨.
- ForEach id는 이미 `\.id`로 정상이므로 rendering은 문제 없고, selection 비교만 문자열 기반이었음.
- Fix: `HomeTopBarState`에 `groupId: UUID?` 필드 추가, `MainTabView`에서 `store.home.family?.id` 전달, 드롭다운 비교를 `family.id == currentGroupId`로 교체.

## Test plan
- [ ] 하트 5+ 상태에서 푸시 알림 탭으로 앱 콜드 스타트 → 질문 상세 → 수정 팝업 확인 버튼 활성
- [ ] 하트 0 상태에서 동일 플로우 → 확인 버튼 비활성(광고 시청만 가능)
- [ ] Home 탭 → 오늘의 질문 카드 탭 경유 회귀 — 정상 동작 유지
- [ ] History 탭에서 과거 질문 진입 회귀
- [ ] 같은 이름 그룹 2개(예: "우리가족" × 2) 생성 → Home 드롭다운에서 하나 선택 → 체크가 그 하나에만
- [ ] 그룹 전환 후 드롭다운 재오픈 → 체크 이동 확인

## Notes
- 근본 개선으로는 `QuestionDetailFeature.State.hearts`를 스냅샷이 아닌 Shared state로 구독하게 하는 리팩터가 바람직하나, 이번 PR은 사용자 영향 긴급도를 감안해 최소 수정만.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)