### PR TITLE
fix(auth): 토큰 만료 시 재로그인 안내 + AppState 초기화 (MG-33)

### DIFF
--- a/MongleData/Sources/MongleData/DataSources/Remote/API/APIClient.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/API/APIClient.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+// MARK: - Session Expired Notification
+
+public extension Notification.Name {
+    /// access/refresh 토큰이 모두 무효화돼 사용자 재로그인이 필요할 때 broadcast.
+    /// RootFeature 가 구독하여 LoginView 전환 + 안내 팝업 표시.
+    static let mongleSessionExpired = Notification.Name("mongle.sessionExpired")
+}
+
 protocol APIClientProtocol: Sendable {
     func request<T: Decodable>(_ endpoint: APIEndpoint) async throws -> T
     func request(_ endpoint: APIEndpoint) async throws
@@ -202,28 +210,38 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
 
     // MARK: - Private: Token Refresh
 
-    /// 리프레시 토큰으로 새 액세스 토큰 발급. 실패 시 `.unauthorized` throw.
+    /// 리프레시 토큰으로 새 액세스 토큰 발급. 실패 시 만료 토큰 폐기 + 세션 만료 신호 post 후 `.unauthorized` throw.
     private func attemptTokenRefresh() async throws -> String {
-        return try await refreshCoordinator.refresh {
-            guard let refreshToken = self.tokenStorage.getRefreshToken() else {
-                throw APIError.unauthorized
-            }
-            let endpoint = AuthEndpoint.refreshToken(refreshToken: refreshToken)
-            var urlRequest = try endpoint.buildURLRequest()
-            // refresh 요청은 토큰 없이 보냄 (만료 토큰 첨부 금지)
-            urlRequest.setValue(nil, forHTTPHeaderField: "Authorization")
+        do {
+            return try await refreshCoordinator.refresh {
+                guard let refreshToken = self.tokenStorage.getRefreshToken() else {
+                    throw APIError.unauthorized
+                }
+                let endpoint = AuthEndpoint.refreshToken(refreshToken: refreshToken)
+                var urlRequest = try endpoint.buildURLRequest()
+                // refresh 요청은 토큰 없이 보냄 (만료 토큰 첨부 금지)
+                urlRequest.setValue(nil, forHTTPHeaderField: "Authorization")
 
-            let (data, response) = try await self.perform(urlRequest)
-            guard response.statusCode == 200 else {
-                // refresh 자체가 401 → 완전한 로그인 필요
-                throw APIError.unauthorized
+                let (data, response) = try await self.perform(urlRequest)
+                guard response.statusCode == 200 else {
+                    // refresh 자체가 401 → 완전한 로그인 필요
+                    throw APIError.unauthorized
+                }
+                let refreshResponse = try self.decoder.decode(RefreshTokenResponseDTO.self, from: data)
+                try self.tokenStorage.saveToken(refreshResponse.token)
+                if let newRefreshToken = refreshResponse.refreshToken {
+                    try self.tokenStorage.saveRefreshToken(newRefreshToken)
+                }
+                return refreshResponse.token
             }
-            let refreshResponse = try self.decoder.decode(RefreshTokenResponseDTO.self, from: data)
-            try self.tokenStorage.saveToken(refreshResponse.token)
-            if let newRefreshToken = refreshResponse.refreshToken {
-                try self.tokenStorage.saveRefreshToken(newRefreshToken)
+        } catch {
+            // 만료된 토큰을 그대로 두면 다음 호출도 401 → 무한 루프. 즉시 폐기.
+            tokenStorage.clearToken()
+            tokenStorage.clearRefreshToken()
+            await MainActor.run {
+                NotificationCenter.default.post(name: .mongleSessionExpired, object: nil)
             }
-            return refreshResponse.token
+            throw error
         }
     }
 

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Action.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Action.swift
@@ -17,6 +17,9 @@ extension RootFeature {
         case checkAuthResponse(User?)
         case loadDataResponse(Result<RootData, Error>)
         case showLoginScreen
+        /// APIClient refresh 실패 신호 수신 → 토큰 폐기 + 로그인 화면 + 안내 팝업
+        case sessionExpired
+        case dismissSessionExpiredPopup
         case logout
         /// 로그아웃 후 다음 runloop tick에 mainTab/questionDetail을 정리
         /// (in-flight onAppear 등 자식 액션이 nil 상태에 도달하지 않도록 분리)

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -6,10 +6,15 @@
 import Foundation
 import ComposableArchitecture
 import Domain
+import MongleData
 import UserNotifications
 import UIKit
 
 extension RootFeature {
+
+    private enum CancelID: Hashable {
+        case sessionExpiredObserver
+    }
 
     var reducer: some ReducerOf<Self> {
 
@@ -25,10 +30,32 @@ extension RootFeature {
                 // MARK: Lifecycle
                 case .onAppear:
                     state.appState = .loading
-                    return .run { send in
-                        let user = try? await authRepository.getCurrentUser()
-                        await send(.checkAuthResponse(user))
-                    }
+                    return .merge(
+                        .run { send in
+                            let user = try? await authRepository.getCurrentUser()
+                            await send(.checkAuthResponse(user))
+                        },
+                        .run { send in
+                            // APIClient.attemptTokenRefresh 실패 시 post 되는 신호를 구독.
+                            // cancelInFlight 로 onAppear 재호출 시 중복 옵저버 방지.
+                            let stream = AsyncStream<Void> { continuation in
+                                let observer = NotificationCenter.default.addObserver(
+                                    forName: .mongleSessionExpired,
+                                    object: nil,
+                                    queue: .main
+                                ) { _ in
+                                    continuation.yield(())
+                                }
+                                continuation.onTermination = { _ in
+                                    NotificationCenter.default.removeObserver(observer)
+                                }
+                            }
+                            for await _ in stream {
+                                await send(.sessionExpired)
+                            }
+                        }
+                        .cancellable(id: CancelID.sessionExpiredObserver, cancelInFlight: true)
+                    )
 
                 case .refreshHomeData:
                     return .run { [authRepository, familyRepository, questionRepository, answerRepository, userRepository, notificationRepository] send in
@@ -306,6 +333,24 @@ extension RootFeature {
                         await Task.yield()
                         await send(.completeLogout)
                     }
+
+                case .sessionExpired:
+                    // APIClient 가 이미 토큰을 폐기했으므로 authRepository.logout() 호출 불필요.
+                    // .logout cleanup 패턴 재사용 + 안내 팝업 플래그 set.
+                    state.showSessionExpiredPopup = true
+                    state.appState = .unauthenticated
+                    state.currentUser = nil
+                    state.loginProviderType = nil
+                    state.login = LoginFeature.State()
+                    state.groupSelect = GroupSelectFeature.State()
+                    return .run { send in
+                        await Task.yield()
+                        await send(.completeLogout)
+                    }
+
+                case .dismissSessionExpiredPopup:
+                    state.showSessionExpiredPopup = false
+                    return .none
 
                 case .logout:
                     // appState만 먼저 전환 → MainTabView가 LoginView로 교체되며 ProfileView 등의 onAppear가 더 이상 dispatch되지 않음

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+State.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+State.swift
@@ -79,6 +79,10 @@ extension RootFeature {
         // MARK: Heart Popup
         public var showHeartGrantedPopup: Bool = false
 
+        // MARK: Session Expired Popup
+        /// 토큰 만료(refresh 실패)로 강제 로그아웃됐을 때 LoginView 위에 띄울 안내 팝업.
+        public var showSessionExpiredPopup: Bool = false
+
         // MARK: Push Navigation
         public var pendingOpenQuestion: Bool = false
 

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/RootView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/RootView.swift
@@ -88,7 +88,26 @@ public struct RootView: View {
                 .transition(.identity)
             }
         }
+        .overlay {
+            // 토큰 만료로 강제 로그아웃된 사용자에게 LoginView 위에 안내 팝업 표시.
+            // appState 가 unauthenticated 일 때만 노출 — 다른 화면 전환 중 popup 잔존 방지.
+            if store.showSessionExpiredPopup && store.appState == .unauthenticated {
+                MonglePopupView(
+                    icon: MonglePopupView.Icon(
+                        systemName: "exclamationmark.triangle.fill",
+                        foregroundColor: .orange,
+                        backgroundColor: Color.orange.opacity(0.12)
+                    ),
+                    title: L10n.tr("error_session_expired_title"),
+                    description: L10n.tr("error_session_expired_desc"),
+                    primaryLabel: L10n.tr("common_confirm"),
+                    onPrimary: { store.send(.dismissSessionExpiredPopup) }
+                )
+                .transition(.identity)
+            }
+        }
         .animation(.none, value: store.showHeartGrantedPopup)
+        .animation(.none, value: store.showSessionExpiredPopup)
         .onOpenURL { url in
             if let code = Self.extractInviteCode(from: url) {
                 store.send(.pendingInviteCode(code))

--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -376,6 +376,8 @@
 "heart_popup_ad" = "Watch ad for hearts";
 "heart_granted_title" = "Heart +1";
 "heart_granted_desc" = "Welcome back today!\nYou received 1 heart.";
+"error_session_expired_title" = "Please sign in again";
+"error_session_expired_desc" = "Your session has expired for security.\nPlease sign in again.";
 "heart_cost" = "%d hearts";
 "heart_earned" = "You earned %d heart!";
 

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -376,6 +376,8 @@
 "heart_popup_ad" = "広告を見てハートをもらう";
 "heart_granted_title" = "ハート +1";
 "heart_granted_desc" = "今日初めてのアクセスですね！\nハートを1つプレゼントしました。";
+"error_session_expired_title" = "再ログインが必要です";
+"error_session_expired_desc" = "セキュリティのためログイン状態が切れました。\n再度ログインしてください。";
 "heart_cost" = "ハート%d個";
 "heart_earned" = "ハート%d個ゲット！";
 

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -376,6 +376,8 @@
 "heart_popup_ad" = "광고 보고 하트 받기";
 "heart_granted_title" = "하트 +1";
 "heart_granted_desc" = "오늘 처음 접속하셨네요!\n하트 1개를 드렸어요.";
+"error_session_expired_title" = "다시 로그인이 필요해요";
+"error_session_expired_desc" = "보안을 위해 로그인 상태가 만료되었어요.\n다시 로그인해 주세요.";
 "heart_cost" = "하트 %d개";
 "heart_earned" = "하트 %d개 획득!";
 


### PR DESCRIPTION
## Jira
- [MG-33](https://ycompany.atlassian.net/browse/MG-33)

## Related
- 직전 PR (review 대기): [MG-32 #47](https://github.com/rrheon/Mongle/pull/47)

## Summary
- `APIClient.attemptTokenRefresh()` 실패 시 만료 토큰 폐기 + `Notification.Name.mongleSessionExpired` post
- `RootFeature` 가 신호 구독 → `appState=.unauthenticated` 전환 + mainTab/questionDetail/login state 초기화
- LoginView 위에 안내 팝업 오버레이 (`error_session_expired_title/desc`, ko/en/ja 동시)
- 토큰 정리 + AppState 초기화로 다음 로그인 시 이전 사용자 데이터 깜빡임 / modal 잔존 / 401 무한 루프 방지

## Test plan
- [ ] 만료 토큰 강제 주입 후 임의 API 호출 → 팝업 → 확인 → LoginView 진입
- [ ] Keychain access/refresh 토큰 모두 삭제 검증
- [ ] 재로그인 시 mainTab 재구성 + 이전 사용자 데이터 깜빡임 없음
- [ ] 다른 사용자 같은 기기 로그인 회귀
- [ ] ko/en/ja 3 locale 문구 정상 표시
- [ ] PerceptionMacros 환경 이슈 해결된 환경에서 풀빌드 검증

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)