### PR TITLE
fix(hearts): 광고 보상 retry + 수정 시 옵티미스틱 차감/롤백 (MG-34)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Common/AdRewardClient.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Common/AdRewardClient.swift
@@ -1,0 +1,38 @@
+//
+//  AdRewardClient.swift
+//  MongleFeatures
+//
+//  광고 보상 하트 지급 호출의 retry 정책을 한 곳에 두기 위한 유틸.
+//  PeerNudgeFeature, QuestionDetailFeature 등 여러 진입점에서 공통 사용.
+//
+
+import Foundation
+import Domain
+
+enum AdRewardClient {
+    /// `userRepository.grantAdHearts(amount:)` 를 최대 `maxRetries` 회 재시도.
+    ///
+    /// - Why: 광고는 이미 시청 완료된 시점에 호출되므로, 일시적 네트워크 오류로
+    ///   보상 지급이 실패하면 사용자는 광고 시간만 손해보고 하트를 받지 못한다.
+    ///   exponential backoff(500ms → 1s → 2s) 로 transient 오류를 흡수한다.
+    /// - Note: 모든 시도가 실패하면 마지막 에러를 throw — 호출부가 명시적 안내 책임.
+    static func grantAdHearts(
+        userRepository: UserRepositoryProtocol,
+        amount: Int,
+        maxRetries: Int = 3
+    ) async throws -> Int {
+        var lastError: Error?
+        for attempt in 0..<maxRetries {
+            do {
+                return try await userRepository.grantAdHearts(amount: amount)
+            } catch {
+                lastError = error
+                if attempt < maxRetries - 1 {
+                    let backoffNanos = UInt64(500_000_000) << attempt // 0.5s, 1s, 2s
+                    try? await Task.sleep(nanoseconds: backoffNanos)
+                }
+            }
+        }
+        throw lastError ?? AppError.unknown("ad reward grant failed")
+    }
+}

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Peer/PeerNudgeFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Peer/PeerNudgeFeature.swift
@@ -3,6 +3,11 @@ import ComposableArchitecture
 
 @Reducer
 public struct PeerNudgeFeature {
+
+    private enum CancelID: Hashable {
+        case nudge
+    }
+
     @ObservableState
     public struct State: Equatable {
         public var targetUserId: String
@@ -73,6 +78,7 @@ public struct PeerNudgeFeature {
                         await send(.nudgeResponse(.failure(AppError.from(error))))
                     }
                 }
+                .cancellable(id: CancelID.nudge, cancelInFlight: true)
 
             case .watchAdTapped:
                 guard !state.isWatchingAd, !state.isSent else { return .none }
@@ -91,8 +97,11 @@ public struct PeerNudgeFeature {
                 let targetUserId = state.targetUserId
                 return .run { [nudgeRepository, userRepository] send in
                     do {
-                        // 광고 보상 하트 지급 (재촉하기 비용 1개)
-                        _ = try await userRepository.grantAdHearts(amount: 1)
+                        // 광고 보상 하트 지급 (재촉하기 비용 1개) — transient 네트워크 오류에 대비한 retry
+                        _ = try await AdRewardClient.grantAdHearts(
+                            userRepository: userRepository,
+                            amount: 1
+                        )
                         // 재촉 전송
                         let heartsRemaining = try await nudgeRepository.sendNudge(targetUserId: targetUserId)
                         await send(.nudgeResponse(.success(heartsRemaining)))
@@ -100,6 +109,7 @@ public struct PeerNudgeFeature {
                         await send(.nudgeResponse(.failure(AppError.from(error))))
                     }
                 }
+                .cancellable(id: CancelID.nudge, cancelInFlight: true)
 
             case .nudgeResponse(.success(let heartsRemaining)):
                 state.isLoading = false

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
@@ -94,6 +94,12 @@ public struct QuestionDetailFeature {
         // MARK: - Presentation Actions
         case editCostPopup(PresentationAction<HeartCostPopupFeature.Action>)
         case adHeartGranted(Int)
+        /// 수정 confirm 후 update API 가 실패했을 때 옵티미스틱 차감을 되돌리기 위한 내부 액션
+        case editRollback
+        /// 광고 시청을 사용자가 취소했거나 보상 미지급된 경우 — submitting 플래그 해제
+        case adWatchAborted
+        /// 광고 시청은 완료했으나 grantAdHearts 가 retry 후에도 실패 — 사용자에게 명시적 안내
+        case adGrantFailed(AppError)
 
         // MARK: - Delegate Actions
         case delegate(Delegate)
@@ -221,6 +227,13 @@ public struct QuestionDetailFeature {
             case .editCostPopup(.presented(.delegate(.confirmed))):
                 state.editCostPopup = nil
                 guard let existingAnswer = state.myAnswer else { return .none }
+                guard state.hearts >= 1 else {
+                    state.appError = .domain(L10n.tr("home_hearts_insufficient"))
+                    return .none
+                }
+                // 옵티미스틱 차감: UI 즉시 반영 + 사용자 즉각 피드백.
+                // 실패 시 .editRollback 으로 되돌린다.
+                state.hearts -= 1
                 state.isSubmitting = true
                 state.appError = nil
 
@@ -242,6 +255,7 @@ public struct QuestionDetailFeature {
                         let result = try await answerRepository.update(updated, moodId: editMoodId)
                         await send(.submitAnswerResponse(.success(result)))
                     } catch {
+                        await send(.editRollback)
                         await send(.submitAnswerResponse(.failure(AppError.from(error))))
                     }
                 }
@@ -252,26 +266,57 @@ public struct QuestionDetailFeature {
 
             case .editCostPopup(.presented(.delegate(.watchAdRequested))):
                 state.editCostPopup = nil
+                state.isSubmitting = true   // 광고 시청 + 보상 지급 + 자동 update 한 묶음으로 락
+                state.appError = nil
                 return .run { [adClient, userRepository] send in
                     let earned = await adClient.showRewardedAd()
-                    guard earned else { return }
+                    guard earned else {
+                        // 사용자가 광고를 끝까지 안 봤거나 reward 콜백 미발화 — submitting 해제
+                        await send(.adWatchAborted)
+                        return
+                    }
                     do {
-                        let heartsRemaining = try await userRepository.grantAdHearts(amount: 1)
+                        // retry 포함 grant. 실패 시 자동 update 진행하지 않고 명시적 안내.
+                        let heartsRemaining = try await AdRewardClient.grantAdHearts(
+                            userRepository: userRepository,
+                            amount: 1
+                        )
                         await send(.adHeartGranted(heartsRemaining))
                     } catch {
-                        await send(.adHeartGranted(-1))
+                        await send(.adGrantFailed(AppError.from(error)))
                     }
                 }
 
+            case .editRollback:
+                // update API 실패 → 옵티미스틱 차감 복구
+                state.hearts += 1
+                return .none
+
+            case .adWatchAborted:
+                state.isSubmitting = false
+                return .none
+
+            case .adGrantFailed(let error):
+                // 광고는 봤지만 서버 보상 지급에 최종 실패. 자동 update 강행하지 않음.
+                // (이전엔 hearts +=1 클라 단독 증가 + 자동 update 진행 → 서버 401/하트 부족 위험)
+                state.isSubmitting = false
+                state.appError = error
+                return .none
+
             case .adHeartGranted(let hearts):
-                if hearts >= 0 {
-                    state.hearts = hearts
-                } else {
-                    state.hearts += 1
-                }
+                // 서버 응답으로만 hearts sync. 실패 분기는 .adGrantFailed 로 분리됨.
+                state.hearts = hearts
                 // 광고 시청 완료 → 수정 작업 자동 실행 (다른 광고 보상 기능과 일관)
-                guard let existingAnswer = state.myAnswer else { return .none }
-                state.isSubmitting = true
+                guard let existingAnswer = state.myAnswer else {
+                    state.isSubmitting = false
+                    return .none
+                }
+                guard state.hearts >= 1 else {
+                    state.isSubmitting = false
+                    state.appError = .domain(L10n.tr("home_hearts_insufficient"))
+                    return .none
+                }
+                state.hearts -= 1   // edit 비용 옵티미스틱 차감
                 state.appError = nil
 
                 let editAnswerText = state.answerText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -292,6 +337,7 @@ public struct QuestionDetailFeature {
                         let result = try await answerRepository.update(updated, moodId: editMoodId)
                         await send(.submitAnswerResponse(.success(result)))
                     } catch {
+                        await send(.editRollback)
                         await send(.submitAnswerResponse(.failure(AppError.from(error))))
                     }
                 }


### PR DESCRIPTION
## Jira
- [MG-34](https://ycompany.atlassian.net/browse/MG-34)

## Related
- audit 5개 도메인 결과 중 결제 영향 Critical 3건 (PR-1)
- 후속: PR-2 (Auth 토큰 일관성), PR-5 (History displayDate), PR-3 (TCA race), PR-4 (i18n+다크모드)

## Summary
- **AdRewardClient 신규** — grantAdHearts retry 3회 (500ms → 1s → 2s)
- **QuestionDetailFeature 옵티미스틱 차감** — confirm 시 hearts -=1, 실패 시 .editRollback으로 +1 복구
- **잘못된 클라 단독 hearts +=1 fallback 제거** — grant 실패 시 자동 update 강행하지 않고 .adGrantFailed로 명시적 안내
- **PeerNudgeFeature .cancellable(id:cancelInFlight:)** — 재촉 race 방어

## Test plan
- [ ] 광고 시청 → grant API 1회 일시 실패 → retry로 정상 회복
- [ ] grant API 3회 모두 실패 → 명시적 에러 토스트, 자동 update 차단
- [ ] 수정 confirm 시 hearts 즉시 -1, update 실패 시 +1 rollback
- [ ] 재촉 버튼 연타 → API 1회만
- [ ] PerceptionMacros 환경 이슈 해결된 환경에서 풀빌드 검증

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)