### PR TITLE
fix(tca): refreshHomeData 취소 + logout pending flag 정리 + Task.yield x2 (MG-37)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -14,6 +14,9 @@ extension RootFeature {
 
     private enum CancelID: Hashable {
         case sessionExpiredObserver
+        /// scenePhase 복귀 등으로 refreshHomeData 가 빠르게 재트리거될 때 이전
+        /// in-flight 요청을 취소하기 위한 ID. cancelInFlight:true 와 함께 사용.
+        case refreshHome
     }
 
     var reducer: some ReducerOf<Self> {
@@ -157,6 +160,7 @@ extension RootFeature {
                             await send(.loadDataResponse(.failure(error)))
                         }
                     }
+                    .cancellable(id: CancelID.refreshHome, cancelInFlight: true)
 
                 case .checkAuthResponse(let user):
                     if let user = user {
@@ -336,9 +340,14 @@ extension RootFeature {
 
                 case .showLoginScreen:
                     // appState만 먼저 전환 → MainTabView가 화면에서 사라짐
-                    // mainTab/questionDetail은 다음 tick에서 정리해 in-flight 자식 액션이 안전히 처리되도록 함
+                    // mainTab/questionDetail은 다음 tick에서 정리해 in-flight 자식 액션이 안전히 처리되도록 함.
+                    // pending push/딥링크 신호는 즉시 비워야 재로그인 시 의도치 않은 자동 이행 방지.
                     state.appState = .unauthenticated
+                    state.pendingOpenQuestion = false
+                    state.pendingInviteCode = nil
                     return .run { send in
+                        // Task.yield() 2회 — in-flight 자식 effect 가 한 번 더 안전히 settle 될 시간 확보.
+                        await Task.yield()
                         await Task.yield()
                         await send(.completeLogout)
                     }
@@ -369,8 +378,11 @@ extension RootFeature {
                     state.loginProviderType = nil
                     state.login = LoginFeature.State()
                     state.groupSelect = GroupSelectFeature.State()
+                    state.pendingOpenQuestion = false
+                    state.pendingInviteCode = nil
                     return .run { [authRepository] send in
                         try? await authRepository.logout()
+                        await Task.yield()
                         await Task.yield()
                         await send(.completeLogout)
                     }


### PR DESCRIPTION
## Jira
- [MG-37](https://ycompany.atlassian.net/browse/MG-37)

## Related
- audit 5도메인 PR-3. PR-1 #51 (hearts), PR-2 #53 (auth), PR-5 server #27.
- 후속: PR-4 (i18n + 다크모드).

## Summary
- refreshHomeData `.cancellable(id:cancelInFlight:true)` — scenePhase 빠른 반복 시 중복 호출 차단
- showLoginScreen/logout `Task.yield()` 2회 — race window 축소
- pendingOpenQuestion/pendingInviteCode logout 시 즉시 정리 — 재로그인 후 stale push/딥링크 자동 발동 방지

## Test plan
- [ ] 백그라운드 ↔ 포그라운드 5회 반복 → refresh API 1회만
- [ ] 푸시 도착 → logout → 재로그인 → 자동 이동 없음
- [ ] 초대링크 → logout → 재로그인 → 자동 join 없음

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)