### PR TITLE
fix(i18n): DateFormatter ko_KR 하드코딩 → Locale.current + 템플릿 (MG-38)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/History/HistoryFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/History/HistoryFeature.swift
@@ -110,9 +110,11 @@ public struct HistoryFeature {
 
         // 해당 월의 이름
         public var monthTitle: String {
+            // 사용자 시스템 로케일 기준으로 "년/월" 형식을 자동 변환.
+            // ko: "2026년 4월", en: "April 2026", ja: "2026年4月"
             let formatter = DateFormatter()
-            formatter.locale = Locale(identifier: "ko_KR")
-            formatter.dateFormat = "yyyy년 M월"
+            formatter.locale = .current
+            formatter.setLocalizedDateFormatFromTemplate("yyyyMMM")
             return formatter.string(from: currentMonth)
         }
 

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/History/HistoryView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/History/HistoryView.swift
@@ -440,15 +440,15 @@ public struct HistoryView: View {
 
     private static let dayFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale(identifier: "ko_KR")
-        f.dateFormat = "d"
+        f.locale = .current
+        f.dateFormat = "d"   // 일 숫자만 — locale 무관
         return f
     }()
 
     private static let selectedDateFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.locale = Locale(identifier: "ko_KR")
-        f.dateFormat = "M월 d일 EEEE"
+        f.locale = .current
+        f.setLocalizedDateFormatFromTemplate("MMMdEEEE")
         return f
     }()
 

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationView.swift
@@ -268,7 +268,7 @@ private struct NotificationCard: View {
 
     private static let relativeFormatter: RelativeDateTimeFormatter = {
         let formatter = RelativeDateTimeFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.locale = .current
         formatter.unitsStyle = .abbreviated
         return formatter
     }()

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Search/SearchHistoryView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Search/SearchHistoryView.swift
@@ -350,8 +350,8 @@ private extension Date {
     var displayLabel: String {
         let cal = Calendar.current
         let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "M월 d일"
+        formatter.locale = .current
+        formatter.setLocalizedDateFormatFromTemplate("MMMd")
         let base = formatter.string(from: self)
         if cal.isDateInToday(self) {
             return "\(base) · 오늘"

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/GroupManagementFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/GroupManagementFeature.swift
@@ -113,8 +113,8 @@ public struct GroupManagementFeature {
                 state.groupName = group.name
                 state.inviteCode = group.inviteCode
                 let formatter = DateFormatter()
-                formatter.locale = Locale(identifier: "ko_KR")
-                formatter.dateFormat = "yyyy년 M월"
+                formatter.locale = .current
+                formatter.setLocalizedDateFormatFromTemplate("yyyyMMM")
                 state.members = users.map { user in
                     let isOwner = user.id == state.familyCreatedById
                     let subtitle = isOwner ? "방장" : formatter.string(from: user.createdAt) + " 가입"

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/HistoryCalendarView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/HistoryCalendarView.swift
@@ -134,11 +134,11 @@ public struct HistoryCalendarView: View {
     // MARK: - Helpers
 
     private static let monthFormatter: DateFormatter = {
-        let f = DateFormatter(); f.locale = Locale(identifier: "ko_KR"); f.dateFormat = "yyyy년 M월"; return f
+        let f = DateFormatter(); f.locale = .current; f.setLocalizedDateFormatFromTemplate("yyyyMMM"); return f
     }()
 
     private static let selectedDateFormatter: DateFormatter = {
-        let f = DateFormatter(); f.locale = Locale(identifier: "ko_KR"); f.dateFormat = "M월 d일 EEEE"; return f
+        let f = DateFormatter(); f.locale = .current; f.setLocalizedDateFormatFromTemplate("MMMdEEEE"); return f
     }()
 
     private var monthTitle: String { Self.monthFormatter.string(from: store.currentMonth) }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/MoodHistoryView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/MoodHistoryView.swift
@@ -149,7 +149,7 @@ public struct MoodHistoryView: View {
     // MARK: - Helpers
 
     private static let moodSummaryFormatter: DateFormatter = {
-        let f = DateFormatter(); f.locale = Locale(identifier: "ko_KR"); f.dateFormat = "M월"; return f
+        let f = DateFormatter(); f.locale = .current; f.setLocalizedDateFormatFromTemplate("MMM"); return f
     }()
 
     private var moodSummarySubtitle: String {


### PR DESCRIPTION
## Jira
- [MG-38](https://ycompany.atlassian.net/browse/MG-38)

## Related
- audit 5도메인 PR-4 (시리즈 마지막).
- PR-1 #51 hearts, PR-2 #53 auth, PR-3 #55 TCA, PR-5 server #27.

## Summary
- 7개 파일 9개 위치의 `Locale("ko_KR")` 하드코딩을 `.current` + `setLocalizedDateFormatFromTemplate` 로 교체
- ko/en/ja 시스템 로케일에 따라 자연스러운 날짜 형식 자동 변환
- audit C10 (Color Set dark variant) 점검 결과 false positive — 모든 Mongle* colorset 이미 dark variant 보유

## Test plan
- [ ] 언어 설정 ko/en/ja 전환 시 history, 알림, 검색 날짜 표기 검증
- [ ] 한국어 환경 기존 표기 유지 회귀

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)