### PR TITLE
fix(badge): 앱 아이콘 배지를 미읽음 알림 수와 동기화 (MG-39)

### DIFF
--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -19,8 +19,11 @@ class MongleAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     weak var store: StoreOf<RootFeature>?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        // 앱 실행 시 아이콘 뱃지 초기화
-        UNUserNotificationCenter.current().setBadgeCount(0)
+        // 배지 카운트는 사용자가 알림함을 실제로 읽거나 비울 때만 갱신한다.
+        // (앱 실행/포그라운드 복귀 시 무조건 0으로 초기화하면 미읽음 17개여도
+        //  사용자가 한 번 앱을 열면 OS 배지가 사라져 인앱 미읽음 카운트와
+        //  완전히 분리되는 버그가 발생 — Root+Reducer.loadDataResponse 가
+        //  refreshHomeData 흐름에서 setBadgeCount(unread) 로 동기화한다.)
         return true
     }
 
@@ -84,8 +87,6 @@ struct MongleApp: App {
         ConsentManager.shared.startConsentFlowIfNeeded()
     }
 
-    @Environment(\.scenePhase) private var scenePhase
-
     var body: some Scene {
         WindowGroup {
             RootView(store: store)
@@ -101,11 +102,6 @@ struct MongleApp: App {
                     appDelegate.store = store
                     UNUserNotificationCenter.current().delegate = appDelegate
                 }
-        }
-        .onChange(of: scenePhase) { _, newPhase in
-            if newPhase == .active {
-                UNUserNotificationCenter.current().setBadgeCount(0)
-            }
         }
     }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationFeature.swift
@@ -8,6 +8,7 @@
 import Foundation
 import ComposableArchitecture
 import Domain
+import UserNotifications
 
 // Domain의 Notification과 이름 충돌 방지
 public typealias MongleNotification = Domain.Notification
@@ -197,6 +198,7 @@ public struct NotificationFeature {
                 let mode = state.mode
                 return .run { [notificationRepository] send in
                     try? await notificationRepository.delete(id: deleteId)
+                    await Self.syncAppIconBadge(notificationRepository)
                     switch mode {
                     case .grouped:
                         if let familyId = notification.familyId {
@@ -223,6 +225,7 @@ public struct NotificationFeature {
                 }
                 return .run { [notificationRepository] _ in
                     _ = try? await notificationRepository.markAsRead(id: notification.id)
+                    await Self.syncAppIconBadge(notificationRepository)
                 }
 
             case .markAllAsRead:
@@ -244,12 +247,14 @@ public struct NotificationFeature {
                 }
                 return .run { [notificationRepository] _ in
                     _ = try? await notificationRepository.markAllAsRead(familyId: scopeFamilyId)
+                    await Self.syncAppIconBadge(notificationRepository)
                 }
 
             case .deleteNotification(let notification):
                 state.notifications = state.notifications.filter { $0.id != notification.id }
                 return .run { [notificationRepository] _ in
                     _ = try? await notificationRepository.delete(id: notification.id)
+                    await Self.syncAppIconBadge(notificationRepository)
                 }
 
             case .deleteAll:
@@ -262,6 +267,7 @@ public struct NotificationFeature {
                 return .run { [notificationRepository] _ in
                     _ = try? await notificationRepository.markAllAsRead(familyId: scopeFamilyId)
                     _ = try? await notificationRepository.deleteAll(familyId: scopeFamilyId)
+                    await Self.syncAppIconBadge(notificationRepository)
                 }
 
             case .dismissError:
@@ -296,5 +302,16 @@ public struct NotificationFeature {
                 return .none
             }
         }
+    }
+
+    /// 인앱 알림 mutation(읽음/삭제) 직후 OS 앱 아이콘 배지를 전체 그룹 합산
+    /// 미읽음 수로 동기화한다. NotificationFeature.state.notifications 는
+    /// .filtered 모드에서는 단일 그룹 데이터만 들고 있어 자체 계산이 부정확하므로,
+    /// `familyId: nil` 로 전체 그룹을 다시 한 번 조회한다.
+    /// (limit 50 cap — 50건 초과 누적은 follow-up 으로 서버 unread-count 라우트 노출)
+    private static func syncAppIconBadge(_ repository: NotificationRepositoryProtocol) async {
+        let all = (try? await repository.getNotifications(limit: 50, familyId: nil)) ?? []
+        let unread = all.filter { !$0.isRead }.count
+        try? await UNUserNotificationCenter.current().setBadgeCount(unread)
     }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -138,6 +138,8 @@ extension RootFeature {
                             let hasUnreadNotifications = notifications.contains {
                                 !$0.isRead && $0.familyId == currentFamilyId
                             }
+                            // OS 앱 아이콘 배지는 사용자 단위(그룹 개념 없음)이므로 전체 그룹 합산.
+                            let unreadCountAllGroups = notifications.filter { !$0.isRead }.count
 
                             return RootData(
                                 user: currentUser,
@@ -152,7 +154,8 @@ extension RootFeature {
                                 memberSkippedStatus: memberSkippedStatus,
                                 streakDays: streakDays,
                                 allFamilies: allFamilies,
-                                hasUnreadNotifications: hasUnreadNotifications
+                                hasUnreadNotifications: hasUnreadNotifications,
+                                unreadCountAllGroups: unreadCountAllGroups
                             )
                             }
                             await send(.loadDataResponse(.success(data)))
@@ -178,6 +181,14 @@ extension RootFeature {
 
                 case .loadDataResponse(.success(let data)):
                     state.currentUser = data.user
+
+                    // OS 앱 아이콘 배지 동기화 — 전체 그룹 합산 미읽음 수.
+                    // refreshHomeData 가 호출되는 모든 경로(앱 콜드 스타트, scenePhase active,
+                    // foreground push 수신, mark-read/delete 직후 등)에서 일관되게 갱신된다.
+                    let badgeCount = data.unreadCountAllGroups
+                    let badgeSyncEffect: Effect<Action> = .run { _ in
+                        try? await UNUserNotificationCenter.current().setBadgeCount(badgeCount)
+                    }
 
                     // 하루 첫 접속 하트 팝업 체크 (그룹별)
                     if let familyId = data.family?.id, data.user != nil {
@@ -287,18 +298,21 @@ extension RootFeature {
                                 hearts: data.user?.hearts ?? 0
                             )))
                         }
-                        return .run { _ in
-                            let key = "mongle.didRequestPushPermission"
-                            if !UserDefaults.standard.bool(forKey: key) {
-                                UserDefaults.standard.set(true, forKey: key)
-                                _ = try? await UNUserNotificationCenter.current()
-                                    .requestAuthorization(options: [.alert, .badge, .sound])
-                            }
-                            // 항상 APNs 토큰 등록 갱신
-                            await MainActor.run {
-                                UIApplication.shared.registerForRemoteNotifications()
-                            }
-                        }
+                        return .merge(
+                            .run { _ in
+                                let key = "mongle.didRequestPushPermission"
+                                if !UserDefaults.standard.bool(forKey: key) {
+                                    UserDefaults.standard.set(true, forKey: key)
+                                    _ = try? await UNUserNotificationCenter.current()
+                                        .requestAuthorization(options: [.alert, .badge, .sound])
+                                }
+                                // 항상 APNs 토큰 등록 갱신
+                                await MainActor.run {
+                                    UIApplication.shared.registerForRemoteNotifications()
+                                }
+                            },
+                            badgeSyncEffect
+                        )
                     }
                     if newAppState == .groupSelection {
                         state.groupSelect.groups = data.allFamilies
@@ -310,7 +324,7 @@ extension RootFeature {
                             state.pendingInviteCode = nil
                         }
                     }
-                    return .none
+                    return badgeSyncEffect
 
                 case .loadDataResponse(.failure(let error)):
                     let appError = AppError.from(error)

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+State.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+State.swift
@@ -23,6 +23,9 @@ extension RootFeature {
         public let streakDays: Int
         public let allFamilies: [MongleGroup]
         public let hasUnreadNotifications: Bool
+        /// OS 앱 아이콘 배지 동기화용 — 전체 그룹 합산 미읽음 수.
+        /// `getNotifications(limit: 50)` 결과 기반이므로 50건 초과 누적 시 50으로 캡됨.
+        public let unreadCountAllGroups: Int
 
         public init(
             user: User?,
@@ -37,7 +40,8 @@ extension RootFeature {
             memberSkippedStatus: [UUID: Bool] = [:],
             streakDays: Int = 0,
             allFamilies: [MongleGroup] = [],
-            hasUnreadNotifications: Bool = false
+            hasUnreadNotifications: Bool = false,
+            unreadCountAllGroups: Int = 0
         ) {
             self.user = user
             self.question = question
@@ -52,6 +56,7 @@ extension RootFeature {
             self.streakDays = streakDays
             self.allFamilies = allFamilies
             self.hasUnreadNotifications = hasUnreadNotifications
+            self.unreadCountAllGroups = unreadCountAllGroups
         }
     }
 


### PR DESCRIPTION
## Jira
- [MG-39](https://ycompany.atlassian.net/browse/MG-39)

## Summary
- 앱 콜드 스타트 / scenePhase active 마다 무조건 `setBadgeCount(0)` 호출하던 2곳 제거
- `Root+Reducer.refreshHomeData` 가 전체 그룹 합산 미읽음 수를 RootData 에 담고, `loadDataResponse(.success)` 에서 `setBadgeCount(unread)` 효과 발행 → 콜드 스타트 / 포그라운드 복귀 / foreground push / mark-read 직후 모든 경로에서 일관 갱신
- `NotificationFeature` 인앱 mutation(읽음/삭제) 직후 `syncAppIconBadge()` 호출 — `familyId:nil` 로 전체 그룹 재조회 후 배지 동기화

## Files changed
| File | LoC |
|---|---|
| `Mongle/MongleApp.swift` | -8/+6 (불필요한 무조건 클리어 + scenePhase onChange 제거) |
| `MongleFeatures/.../Root/Ext/Root+State.swift` | +6/-1 (`unreadCountAllGroups` 필드) |
| `MongleFeatures/.../Root/Ext/Root+Reducer.swift` | +25/-13 (badgeSyncEffect + .merge) |
| `MongleFeatures/.../Notification/NotificationFeature.swift` | +17/-1 (5 mutation actions + private static helper) |

## Test plan
- [ ] 미읽음 17개 → 앱 콜드 스타트 → 홈 화면 배지 17 유지
- [ ] 앱 백그라운드 → 포그라운드 복귀 시 배지 유지 (서버 미읽음 수와 동기화)
- [ ] 알림 1건 markAsRead → 배지 16 즉시 감소
- [ ] markAllAsRead (.all 모드) → 배지 0
- [ ] markAllAsRead (.filtered 모드, 그룹 A) → 그룹 B 미읽음 12 → 배지 12 (다른 그룹 보존)
- [ ] deleteNotification / deleteAll 동일 검증
- [ ] notificationTapped (탭 후 자동 삭제) 도 배지 즉시 감소
- [ ] Push 수신 (foreground) → 서버가 보낸 배지 값으로 OS 갱신 + refreshHomeData 로 인앱 동기화

## Known limitation
`getNotifications(limit: 50)` 기반 클라 동기화라 50+ 누적 시 배지 50으로 캡. 서버 푸시는 정확한 수치 사용 → 새 알림 도착 시 자동 보정. 50+ 사례 발견 시 follow-up:
- 서버: `NotificationController.ts` 에 `GET /notifications/unread-count` 라우트 노출 (`NotificationService.getUnreadCount` 이미 구현됨)
- iOS: `NotificationRepository.getUnreadCount()` 메서드 추가, `syncAppIconBadge` 와 RootReducer 가 이 endpoint 사용

## Notes
- audit 시리즈 (PR #45-57) 와 별개 트랙. 동일 파일(Root+Reducer / Root+State / NotificationFeature) 을 건드리지만 audit PR 들은 모두 머지 완료 (PR #45/47/49/53/51 머지, #55/57 review 대기) 라 충돌 없이 main 위에 빌드.
- 서버 변경 0 — 서버는 이미 정상 동작.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)