### PR TITLE
fix(ios): APNs cold start + sessionExpired pending + deeplink consume (MG-47)

### DIFF
--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -85,6 +85,13 @@ struct MongleApp: App {
         // GDPR/CCPA 동의 흐름(UMP). KR·JP 는 건너뛰고 즉시 AdMob 초기화,
         // 그 외 지역은 동의 폼 표시 후 AdMob 초기화한다.
         ConsentManager.shared.startConsentFlowIfNeeded()
+        // store / UNUserNotificationCenter delegate 를 init 시점에 즉시 연결.
+        // 이전엔 .onAppear 에서 할당했는데, cold start 직후 didFinishLaunching 보다
+        // .onAppear 가 늦게 발화하는 경우가 있어 didRegisterForRemoteNotificationsWithDeviceToken
+        // 콜백이 들어와도 store==nil 이라 deviceTokenReceived 액션이 사실상 누락되던
+        // 케이스(APNs 토큰 미등록 → 푸시 안 옴)를 방어.
+        appDelegate.store = store
+        UNUserNotificationCenter.current().delegate = appDelegate
     }
 
     var body: some Scene {
@@ -97,10 +104,6 @@ struct MongleApp: App {
                     if !isInviteLink {
                         SocialSDK.handle(url: url)
                     }
-                }
-                .onAppear {
-                    appDelegate.store = store
-                    UNUserNotificationCenter.current().delegate = appDelegate
                 }
         }
     }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -277,9 +277,16 @@ extension RootFeature {
                     // refreshHomeData 호출) authenticated 로 강제 전환하지 않는다.
                     // 사용자가 "홈으로" 를 눌러 step 이 .select 로 리셋된 뒤에만 전환된다.
                     let preserveInviteCodeScreen = wasOnGroupSelect && state.groupSelect.step == .groupCreated
+                    // 인증 미완료 상태(consentRequired/emailSignup) 동안 들어온 딥링크가
+                    // pendingInviteCode 에 남아있다면, 인증 완료 후 곧장 .authenticated 로
+                    // 가지 말고 .groupSelection 으로 한 단계 거쳐 join 화면을 띄운다.
+                    // 그렇지 않으면 코드가 영영 소비되지 않고 stale 상태로 남는 버그 (audit High).
+                    let hasPendingInvite = state.pendingInviteCode != nil
                     let newAppState: RootFeature.State.AppState = preserveInviteCodeScreen
                         ? .groupSelection
-                        : ((data.family == nil || isInitialLoad) ? .groupSelection : .authenticated)
+                        : (hasPendingInvite || data.family == nil || isInitialLoad
+                           ? .groupSelection
+                           : .authenticated)
                     // 그룹 선택 화면에서 인증 완료 전환 시 HomeTab으로 리셋
                     if wasOnGroupSelect && newAppState == .authenticated {
                         state.mainTab?.selectedTab = .home
@@ -375,6 +382,10 @@ extension RootFeature {
                     state.loginProviderType = nil
                     state.login = LoginFeature.State()
                     state.groupSelect = GroupSelectFeature.State()
+                    // pending push/딥링크 신호도 즉시 비워야 재로그인 시 의도치 않은 자동 이행 방지.
+                    // .logout / .showLoginScreen 과 동일한 cleanup 으로 통일.
+                    state.pendingOpenQuestion = false
+                    state.pendingInviteCode = nil
                     return .run { send in
                         await Task.yield()
                         await send(.completeLogout)


### PR DESCRIPTION
## Jira
- [MG-47](https://ycompany.atlassian.net/browse/MG-47)

## Related
- 1차 audit MG-32 (PR #47, 머지) — 딥링크 hearts + 동명 그룹 fix
- 1차 audit MG-33 (PR #49, 머지) — 토큰 만료 → 재로그인
- 동명 패턴: completeLogout / showLoginScreen / logout (이미 명시 cleanup)

## Summary
- MongleApp init 에서 store/UN delegate 즉시 할당 — cold start race 차단
- sessionExpired pending cleanup 통일
- 미인증 상태 딥링크 코드 → groupSelection 강제 라우팅 (line 321 소비 로직 활용)
- MongleData scheme BUILD SUCCEEDED. MongleFeatures scheme 사전 존재 AdRewardClient 격리 이슈로 fail (변경 무관)

## Test plan
- [ ] cold start 직후 APNs 토큰 등록 (서버 DB apns_token 확인)
- [ ] sessionExpired 후 재로그인 → 이전 push 의도치 않은 동작 없음
- [ ] consent 화면에서 딥링크 → consent 완료 → joinWithCode 자동 진입
- [ ] 정상 로그인 회귀 없음

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)