### PR TITLE
fix(ios): switchFamily race + completeLogout cancel (MG-48)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -17,6 +17,8 @@ extension RootFeature {
         /// scenePhase 복귀 등으로 refreshHomeData 가 빠르게 재트리거될 때 이전
         /// in-flight 요청을 취소하기 위한 ID. cancelInFlight:true 와 함께 사용.
         case refreshHome
+        /// 그룹 빠른 연속 전환 시 이전 in-flight 요청 취소.
+        case switchFamily
     }
 
     var reducer: some ReducerOf<Self> {
@@ -405,7 +407,13 @@ extension RootFeature {
                     state.mainTab = nil
                     state.questionDetail = nil
                     state.selectedQuestion = nil
-                    return .none
+                    // 로그아웃 직전에 in-flight 였던 refreshHome/switchFamily 효과들이
+                    // 뒤늦게 settle 되며 nil 이 된 mainTab 에 액션을 dispatch 하지 않도록
+                    // 명시 취소. sessionExpiredObserver 는 다음 onAppear 에서 재구독되도록 유지.
+                    return .merge(
+                        .cancel(id: CancelID.refreshHome),
+                        .cancel(id: CancelID.switchFamily)
+                    )
 
                 // MARK: MainTab Delegate
                 case .mainTab(.delegate(.navigateToQuestionDetail)):
@@ -447,6 +455,10 @@ extension RootFeature {
                             await send(.loadDataResponse(.failure(error)))
                         }
                     }
+                    // 빠른 연속 전환 시 이전 selectFamily/refreshHomeData chain 을 취소.
+                    // 이전엔 두 in-flight 가 임의 순서로 settle 되며 서버/클라 활성 가족이
+                    // 어긋나는 케이스가 있었음.
+                    .cancellable(id: CancelID.switchFamily, cancelInFlight: true)
 
                 case .switchFamilyResponse:
                     return .none


### PR DESCRIPTION
## Jira
- [MG-48](https://ycompany.atlassian.net/browse/MG-48)

## Related
- 1차 audit MG-37 (PR #55, 머지) — TCA race (refreshHome cancellable 추가)
- 동일 패턴 확장: switchFamily 도 cancellable 으로 보호.
- 1차 audit MG-33 (PR #49, 머지) — sessionExpired

## Summary
- CancelID.switchFamily 추가
- switchFamily .cancellable(cancelInFlight:true)
- completeLogout 에서 in-flight effect 명시 cancel
- BUILD SUCCEEDED

## Note: questionDetail sheet 이중 마운트 잔여
- RootView.sheet(item: questionDetail) 와 MainTabView.sheet(item: modal?.questionSheet) 공존이 audit 에서 우려되었으나, 코드 추적 결과 RootFeature.questionDetail 는 어디에서도 non-nil 로 set 되지 않는 dead 경로. 현재 시점에 이중 마운트 발생 안 함. 추후 정리 시 dead state/sheet 제거 follow-up.

## Test plan
- [ ] 그룹 빠른 연속 전환 → 최종 선택 데이터만 표시 (race 검증)
- [ ] 로그아웃 직후 LoginView 에서 추가 자동 액션 없음
- [ ] 정상 그룹 전환 / 정상 로그아웃 회귀 없음

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)