### PR TITLE
fix(ios): QuestionDetail hearts re-fetch (MG-49)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
@@ -90,6 +90,8 @@ public struct QuestionDetailFeature {
         case loadDataResponse(Result<LoadedData, AppError>)
         case submitAnswerResponse(Result<Answer, AppError>)
         case setAppError(AppError?)
+        /// 다중 디바이스에서 hearts 가 변경됐을 수 있으므로 onAppear 마다 최신 값으로 갱신.
+        case heartsRefreshed(Int)
 
         // MARK: - Presentation Actions
         case editCostPopup(PresentationAction<HeartCostPopupFeature.Action>)
@@ -122,6 +124,7 @@ public struct QuestionDetailFeature {
     }
 
     @Dependency(\.answerRepository) var answerRepository
+    @Dependency(\.authRepository) var authRepository
     @Dependency(\.userRepository) var userRepository
     @Dependency(\.adClient) var adClient
     @Dependency(\.errorHandler) var errorHandler
@@ -143,23 +146,38 @@ public struct QuestionDetailFeature {
                 let questionId = state.question.id
                 let currentUserId = state.currentUser?.id
                 let members = state.familyMembers
-                return .run { [answerRepository] send in
-                    do {
-                        let answers = try await answerRepository.getByDailyQuestion(dailyQuestionId: questionId)
-                        let myAnswer = answers.first(where: { $0.userId == currentUserId })
-                        let familyAnswers: [State.FamilyAnswer] = answers
-                            .filter { $0.userId != currentUserId }
-                            .map { answer in
-                                let user = members.first(where: { $0.id == answer.userId })
-                                    ?? User(id: answer.userId, email: "", name: "멤버",
-                                            profileImageURL: nil, role: .other, createdAt: Date())
-                                return State.FamilyAnswer(user: user, answer: answer)
-                            }
-                        await send(.loadDataResponse(.success(LoadedData(myAnswer: myAnswer, familyAnswers: familyAnswers))))
-                    } catch {
-                        await send(.loadDataResponse(.failure(AppError.from(error))))
+                return .merge(
+                    .run { [answerRepository] send in
+                        do {
+                            let answers = try await answerRepository.getByDailyQuestion(dailyQuestionId: questionId)
+                            let myAnswer = answers.first(where: { $0.userId == currentUserId })
+                            let familyAnswers: [State.FamilyAnswer] = answers
+                                .filter { $0.userId != currentUserId }
+                                .map { answer in
+                                    let user = members.first(where: { $0.id == answer.userId })
+                                        ?? User(id: answer.userId, email: "", name: "멤버",
+                                                profileImageURL: nil, role: .other, createdAt: Date())
+                                    return State.FamilyAnswer(user: user, answer: answer)
+                                }
+                            await send(.loadDataResponse(.success(LoadedData(myAnswer: myAnswer, familyAnswers: familyAnswers))))
+                        } catch {
+                            await send(.loadDataResponse(.failure(AppError.from(error))))
+                        }
+                    },
+                    // 다중 디바이스 hearts sync — 다른 기기에서 답변/스킵/위시 등으로 hearts 가
+                    // 바뀌었을 수 있으므로 questionDetail 진입 시 서버 최신 값을 가져온다.
+                    // 이전엔 부모 화면에서 캡처한 stale hearts 로 editCostPopup/adReward 가 동작해
+                    // 서버 검증과 어긋나는 경우가 있었음.
+                    .run { [authRepository] send in
+                        if let user = try? await authRepository.getCurrentUser() {
+                            await send(.heartsRefreshed(user.hearts))
+                        }
                     }
-                }
+                )
+
+            case .heartsRefreshed(let hearts):
+                state.hearts = hearts
+                return .none
 
             case .answerTextChanged(let text):
                 guard !state.isSubmitting else { return .none }


### PR DESCRIPTION
## Jira
- [MG-49](https://ycompany.atlassian.net/browse/MG-49)

## Related
- 1차 audit MG-34 (PR #51, 머지) — hearts ad-reward race
- 2차 audit MG-45 (PR #39) — Server hearts 음수 가드

## Summary
- QuestionDetailFeature.onAppear hearts 재조회 (서버 최신 값)
- authRepository.getCurrentUser → heartsRefreshed(hearts)
- BUILD SUCCEEDED

## Test plan
- [ ] 다중 디바이스: A 에서 hearts 변동 후 B questionDetail 진입 시 최신 값
- [ ] 단일 디바이스 회귀 없음
- [ ] 네트워크 실패 시에도 답변 로딩에 영향 없음 (.merge 라 독립 실행)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)