### PR TITLE
fix(ios): 게스트 모드 게이트 보강 (MG-50)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Home/HomeFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Home/HomeFeature.swift
@@ -164,6 +164,10 @@ public struct HomeFeature {
                 return .send(.delegate(.showQuestionSheet(question)))
 
             case .notificationTapped:
+                if state.isGuest {
+                    state.showGuestLoginPrompt = true
+                    return .none
+                }
                 return .send(.delegate(.navigateToNotifications))
 
             case .heartsTapped:
@@ -216,6 +220,10 @@ public struct HomeFeature {
                 return .none
 
             case .nudgeUnavailableTapped(let memberName):
+                if state.isGuest {
+                    state.showGuestLoginPrompt = true
+                    return .none
+                }
                 return .send(.delegate(.showNudgeUnavailablePopup(memberName)))
 
             case .refreshData:

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/Ext/MainTab+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/Ext/MainTab+Reducer.swift
@@ -427,6 +427,12 @@ extension MainTabFeature {
 
                 case .modal(.presented(.answerFirstPopup(.delegate(.answerNow)))):
                     state.modal = nil
+                    // 게스트 모드에서 답변 화면 진입 차단 — 다른 경로(딥링크/직접 호출)로
+                    // 이 delegate 가 들어와도 일관되게 로그인 팝업으로 라우팅한다.
+                    if state.home.isGuest {
+                        state.home.showGuestLoginPrompt = true
+                        return .none
+                    }
                     guard let question = state.home.todayQuestion else { return .none }
                     return .run { send in
                         await send(.delegate(.navigateToQuestionDetail(question)))


### PR DESCRIPTION
## Jira
- [MG-50](https://ycompany.atlassian.net/browse/MG-50)

## Summary
사용자 보고 — 로그인 안 한 상태에서 home 캐릭터 클릭 시 답변 화면 진입 가능.
- HomeFeature.nudgeUnavailableTapped + notificationTapped isGuest 처리 누락
- MainTab.answerFirstPopup.answerNow → navigateToQuestionDetail 직결 (방어 가드 부재)

3개 지점에 일관 패턴 (showGuestLoginPrompt = true) 적용.

## Test plan
- [ ] 게스트 모드 → 캐릭터 클릭 (모든 상태) → 로그인 팝업
- [ ] 게스트 모드 → 알림 아이콘/하트/그룹 → 로그인 팝업
- [ ] 정상 로그인 사용자 캐릭터/알림/답변 흐름 회귀 없음

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)