### PR TITLE
fix(ios): 토큰 흐름 안정화 (MG-53)

### DIFF
--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import ComposableArchitecture
+import MongleData
 import MongleFeatures
 import GoogleMobileAds
 import UIKit
@@ -80,6 +81,15 @@ struct MongleApp: App {
     }
 
     init() {
+        // Install sentinel — iOS 는 앱 uninstall 시 Keychain 항목을 자동 정리하지 않아
+        // 재설치 사용자가 이전 사용자 토큰으로 자동 로그인되는 케이스가 있다. 첫 실행
+        // 마커가 없으면 (= 새 install) 기존 토큰을 명시적으로 폐기한다.
+        let installSentinelKey = "mongle.installSentinel"
+        if !UserDefaults.standard.bool(forKey: installSentinelKey) {
+            clearTokensOnFreshInstall()
+            UserDefaults.standard.set(true, forKey: installSentinelKey)
+        }
+
         MongleFont.registerFonts()
         SocialSDK.initialize()
         // GDPR/CCPA 동의 흐름(UMP). KR·JP 는 건너뛰고 즉시 AdMob 초기화,

--- a/MongleData/Sources/MongleData/DataSources/Local/UserDefaultsManager.swift
+++ b/MongleData/Sources/MongleData/DataSources/Local/UserDefaultsManager.swift
@@ -51,3 +51,37 @@ extension UserDefaultsManager {
         static let receivedMessages = "received_messages"
     }
 }
+
+// MARK: - User-scoped Cleanup
+
+/// 로그아웃 / 세션 만료 / 회원 탈퇴 시 호출. `mongle_*`, `mongle.*`, `notification.*`,
+/// `mongle_notifications_enabled` 같은 사용자 단위 키를 일괄 정리해 다른 계정 로그인 시
+/// 이전 사용자의 그룹별 팝업/리마인더 시간/뱃지 상태가 새 사용자에게 잘못 적용되는
+/// 문제를 방지한다. 단, 디바이스 단위로 보존해야 하는 키는 제외:
+///   - `mongle.hasSeenOnboarding` — 디바이스 첫 사용자만 온보딩 보여줌
+///   - `mongle.installSentinel` — 첫 실행 마커 (Keychain 잔존 정리용)
+public enum UserDefaultsCleanup {
+    private static let preserveKeys: Set<String> = [
+        "mongle.hasSeenOnboarding",
+        "mongle.installSentinel",
+    ]
+
+    private static let userScopedPrefixes = [
+        "mongle.",
+        "mongle_",
+        "notification.",
+    ]
+
+    public static func clearUserScoped(_ defaults: UserDefaults = .standard) {
+        let dict = defaults.dictionaryRepresentation()
+        for key in dict.keys {
+            if preserveKeys.contains(key) { continue }
+            for prefix in userScopedPrefixes {
+                if key.hasPrefix(prefix) {
+                    defaults.removeObject(forKey: key)
+                    break
+                }
+            }
+        }
+    }
+}

--- a/MongleData/Sources/MongleData/DataSources/Remote/API/APIClient.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/API/APIClient.swift
@@ -43,6 +43,13 @@ private actor TokenRefreshCoordinator {
 // MARK: - APIClient
 
 final class APIClient: APIClientProtocol, @unchecked Sendable {
+    /// 모든 Repository 가 공유해야 하는 단일 인스턴스.
+    /// 각 Repository 가 자체 APIClient() 를 생성하면 refreshCoordinator 가 분리되어
+    /// cold start + scenePhase active + push 동시 401 발생 시 refresh 가 N회 동시 호출되며
+    /// MG-42 의 refresh token rotation 이 replay 로 감지해 강제 로그아웃이 발생한다.
+    /// Repository 의 default 인자에서도 이 shared 인스턴스를 사용해 Coordinator 일원화.
+    static let shared = APIClient()
+
     private let session: URLSession
     private let decoder: JSONDecoder
     private let tokenStorage: TokenStorageProtocol

--- a/MongleData/Sources/MongleData/DataSources/Remote/Services/AuthAPIService.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/Services/AuthAPIService.swift
@@ -8,7 +8,7 @@ protocol AuthAPIServiceProtocol {
 final class AuthAPIService: AuthAPIServiceProtocol {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol = APIClient.shared) {
         self.apiClient = apiClient
     }
 

--- a/MongleData/Sources/MongleData/DataSources/Remote/Services/UserAPIService.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/Services/UserAPIService.swift
@@ -8,7 +8,7 @@ protocol UserAPIServiceProtocol {
 final class UserAPIService: UserAPIServiceProtocol {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol = APIClient.shared) {
         self.apiClient = apiClient
     }
 

--- a/MongleData/Sources/MongleData/MongleData.swift
+++ b/MongleData/Sources/MongleData/MongleData.swift
@@ -42,4 +42,20 @@ public func makeNotificationRepository() -> any NotificationRepositoryProtocol {
     NotificationRepository()
 }
 
+// MARK: - 첫 실행 / 로그아웃 시 정리 헬퍼
+
+/// iOS 는 앱 uninstall 후 재설치 시 Keychain 항목을 자동으로 지우지 않는다.
+/// 첫 실행 마커가 없는 새 install 에서 호출하면 이전 사용자의 토큰을 명시적으로 폐기한다.
+/// 앱 entry (MongleApp.init) 에서 호출.
+public func clearTokensOnFreshInstall() {
+    let storage = KeychainTokenStorage()
+    storage.clearToken()
+    storage.clearRefreshToken()
+}
+
+/// 사용자 단위 UserDefaults 키를 일괄 정리. 로그아웃 / 세션 만료 / 회원 탈퇴 시 호출.
+public func clearUserScopedDefaults() {
+    UserDefaultsCleanup.clearUserScoped()
+}
+
 

--- a/MongleData/Sources/MongleData/Repositories/AnswerRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/AnswerRepository.swift
@@ -11,7 +11,7 @@ import Domain
 final class AnswerRepository: AnswerRepositoryInterface {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol = APIClient.shared) {
         self.apiClient = apiClient
     }
 

--- a/MongleData/Sources/MongleData/Repositories/AuthRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/AuthRepository.swift
@@ -14,7 +14,7 @@ final class AuthRepository: AuthRepositoryInterface {
     private let tokenStorage: TokenStorageProtocol
 
     init(
-        apiClient: APIClientProtocol = APIClient(),
+        apiClient: APIClientProtocol = APIClient.shared,
         tokenStorage: TokenStorageProtocol = KeychainTokenStorage()
     ) {
         self.apiClient = apiClient

--- a/MongleData/Sources/MongleData/Repositories/DailyQuestionRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/DailyQuestionRepository.swift
@@ -11,7 +11,7 @@ import Domain
 final class DailyQuestionRepository: DailyQuestionRepositoryInterface {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol = APIClient.shared) {
         self.apiClient = apiClient
     }
 

--- a/MongleData/Sources/MongleData/Repositories/FamilyRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/FamilyRepository.swift
@@ -11,7 +11,7 @@ import Domain
 final class FamilyRepository: MongleRepositoryInterface {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol = APIClient.shared) {
         self.apiClient = apiClient
     }
 

--- a/MongleData/Sources/MongleData/Repositories/MoodRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/MoodRepository.swift
@@ -4,7 +4,7 @@ import Domain
 final class MoodRepository: MoodRepositoryProtocol {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol = APIClient.shared) {
         self.apiClient = apiClient
     }
 

--- a/MongleData/Sources/MongleData/Repositories/NotificationRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/NotificationRepository.swift
@@ -4,7 +4,7 @@ import Domain
 final class NotificationRepository: NotificationRepositoryProtocol {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol = APIClient.shared) {
         self.apiClient = apiClient
     }
 

--- a/MongleData/Sources/MongleData/Repositories/NudgeRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/NudgeRepository.swift
@@ -4,7 +4,7 @@ import Domain
 final class NudgeRepository: NudgeRepositoryInterface {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol = APIClient.shared) {
         self.apiClient = apiClient
     }
 

--- a/MongleData/Sources/MongleData/Repositories/QuestionRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/QuestionRepository.swift
@@ -11,7 +11,7 @@ import Domain
 final class QuestionRepository: QuestionRepositoryInterface {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol = APIClient.shared) {
         self.apiClient = apiClient
     }
 

--- a/MongleData/Sources/MongleData/Repositories/UserRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/UserRepository.swift
@@ -11,7 +11,7 @@ import Domain
 final class UserRepository: UserRepositoryInterface {
     private let apiClient: APIClientProtocol
 
-    init(apiClient: APIClientProtocol = APIClient()) {
+    init(apiClient: APIClientProtocol = APIClient.shared) {
         self.apiClient = apiClient
     }
 

--- a/MongleFeatures/Sources/MongleFeatures/AppLifecycleSupport.swift
+++ b/MongleFeatures/Sources/MongleFeatures/AppLifecycleSupport.swift
@@ -9,6 +9,7 @@
 import Foundation
 import KakaoSDKCommon
 import KakaoSDKAuth
+import KakaoSDKUser
 import GoogleSignIn
 
 public enum SocialSDK {
@@ -25,5 +26,17 @@ public enum SocialSDK {
             return AuthController.handleOpenUrl(url: url)
         }
         return GIDSignIn.sharedInstance.handle(url)
+    }
+
+    /// 모든 소셜 SDK 의 로컬 세션 토큰을 비웁니다 (logout). unlink/disconnect 와는 별개.
+    /// 동일 디바이스에서 다른 계정 로그인 시 SDK 캐시로 인한 자동 로그인 방지용.
+    /// 로그아웃 / 세션 만료 / 회원 탈퇴 후 일관 호출.
+    public static func clearAllSessions() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            UserApi.shared.logout { _ in
+                continuation.resume()
+            }
+        }
+        GIDSignIn.sharedInstance.signOut()
     }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Login/SocialLoginProvider.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Login/SocialLoginProvider.swift
@@ -28,6 +28,18 @@ public protocol SocialLoginProvider {
     /// - Kakao: unlink (앱 연결 해제)
     /// - Google: disconnect (앱 접근 권한 해제)
     func revokeClientAccess() async throws
+
+    /// 클라이언트 측 SDK 토큰만 정리 (logout — unlink 와 별개).
+    /// 동일 디바이스에서 다른 계정 로그인 시 SDK 가 캐시된 토큰으로 자동 로그인되어
+    /// 이전 계정 컨텍스트가 노출되는 것을 방어한다.
+    /// - Apple: no-op (Apple SDK 가 자체 캐시 미보관)
+    /// - Kakao: UserApi.shared.logout
+    /// - Google: GIDSignIn.sharedInstance.signOut
+    func clearClientSession() async
+}
+
+public extension SocialLoginProvider {
+    func clearClientSession() async {}
 }
 
 // MARK: - Apple 로그인 제공자
@@ -209,6 +221,17 @@ public final class KakaoLoginProvider: SocialLoginProvider {
             }
         }
     }
+
+    /// 카카오 SDK 의 로컬 OAuthToken 만 비움 (unlink 와 별개).
+    /// 같은 기기에서 다른 카카오 계정으로 로그인 시 캐시된 토큰으로 자동 로그인되어
+    /// 이전 계정의 카카오 ID 가 그대로 사용되던 문제 방어. 실패해도 무시 (best-effort).
+    public func clearClientSession() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            UserApi.shared.logout { _ in
+                continuation.resume()
+            }
+        }
+    }
 }
 
 enum KakaoLoginError: Error {
@@ -250,6 +273,12 @@ public final class GoogleLoginProvider: SocialLoginProvider {
     /// 연결 해제 후 재로그인 시 동의 화면이 다시 표시됩니다.
     public func revokeClientAccess() async throws {
         try await GIDSignIn.sharedInstance.disconnect()
+    }
+
+    /// Google SDK 의 currentUser 만 sign-out (disconnect 와 별개).
+    /// 같은 기기에서 다른 계정 로그인 시 이전 계정 자동 로그인 방어.
+    public func clearClientSession() async {
+        GIDSignIn.sharedInstance.signOut()
     }
 }
 

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -418,12 +418,18 @@ extension RootFeature {
                     state.mainTab = nil
                     state.questionDetail = nil
                     state.selectedQuestion = nil
+                    // 사용자 단위 UserDefaults 키 일괄 정리 — 다음 계정 로그인 시 이전 사용자의
+                    // 그룹별 알림 설정 / 리마인더 시간 / 팝업 노출 마커 등이 잘못 적용되는 것을
+                    // 방지. mongle.hasSeenOnboarding / mongle.installSentinel 은 보존.
+                    clearUserScopedDefaults()
                     // 로그아웃 직전에 in-flight 였던 refreshHome/switchFamily 효과들이
                     // 뒤늦게 settle 되며 nil 이 된 mainTab 에 액션을 dispatch 하지 않도록
-                    // 명시 취소. sessionExpiredObserver 는 다음 onAppear 에서 재구독되도록 유지.
+                    // 명시 취소 + 소셜 SDK 캐시 토큰 정리 (Kakao logout / Google signOut) 도
+                    // best-effort 로 수행. sessionExpiredObserver 는 다음 onAppear 에서 재구독.
                     return .merge(
                         .cancel(id: CancelID.refreshHome),
-                        .cancel(id: CancelID.switchFamily)
+                        .cancel(id: CancelID.switchFamily),
+                        .run { _ in await SocialSDK.clearAllSessions() }
                     )
 
                 // MARK: MainTab Delegate


### PR DESCRIPTION
## Jira
- [MG-53](https://ycompany.atlassian.net/browse/MG-53)

## Related
- 1차 audit MG-35 (PR #53 머지) — Auth 토큰 일관성
- MG-33 (PR #49) — APIClient mongleSessionExpired 신호
- MG-42 (Server PR #33) — refresh token rotation/replay

## Summary
- APIClient.shared 싱글턴 — refreshCoordinator 통합 (replay 오감지 방지)
- MongleApp install sentinel — uninstall→재설치 잔존 토큰 폐기
- SocialSDK.clearAllSessions / clearClientSession 프로토콜 확장
- UserDefaultsCleanup.clearUserScoped — user-scoped 키 정리 헬퍼
- BUILD SUCCEEDED

## Test plan
- [ ] 동시 401 다발 시 refresh 1회만 호출 (CloudWatch + iOS 로그)
- [ ] 앱 삭제→재설치 → 로그인 화면 (자동 로그인 X)
- [ ] Kakao 계정 전환 → 캐시 토큰 자동 로그인 X
- [ ] 계정 전환 시 알림 시간/그룹 설정 누수 X
- [ ] 정상 로그인/로그아웃 회귀 없음

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)