### PR TITLE
fix(ios): background/push stabilization (MG-55)

### DIFF
--- a/Domain/Sources/Domain/Repositories/NotificationRepositoryProtocol.swift
+++ b/Domain/Sources/Domain/Repositories/NotificationRepositoryProtocol.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public protocol NotificationRepositoryProtocol: Sendable {
     func getNotifications(limit: Int, familyId: UUID?) async throws -> [Notification]
+    func getUnreadCount() async throws -> Int
     func markAsRead(id: UUID) async throws -> Notification
     func markAllAsRead(familyId: UUID?) async throws -> Int
     func delete(id: UUID) async throws

--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -32,18 +32,32 @@ class MongleAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         store?.send(.deviceTokenReceived(deviceToken))
     }
 
+    /// APNs 토큰 등록 실패 — 디버깅 단서 + 서버 측 stale 토큰 유지 방지를 위한 로그.
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        let nsError = error as NSError
+        print("[APNs] 토큰 등록 실패: domain=\(nsError.domain) code=\(nsError.code) description=\(nsError.localizedDescription)")
+    }
+
     /// 포그라운드에서 알림 수신 시 배너 표시 + 홈 알림 배지 즉시 갱신
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        completionHandler([.banner, .sound, .badge])
+        // 사용자가 가입/동의/로그인 흐름 도중일 때는 푸시 배너가 흐름을 끊지 않도록
+        // 배너는 숨기고 알림 리스트에만 저장 ([.list, .badge]). authenticated/groupSelection
+        // 상태에서만 평소처럼 배너 노출.
+        let appState = store?.state.appState
+        let canShowBanner = appState == .authenticated || appState == .groupSelection
+        if canShowBanner {
+            completionHandler([.banner, .sound, .badge])
+        } else {
+            completionHandler([.list, .badge])
+        }
         // 포그라운드 push 가 도착했을 때 홈 배지 갱신은 authenticated 상태에서만 의미가 있다.
         // 그룹 선택/초대코드/로그인/동의 화면 중에는 refreshHomeData 가 loadDataResponse 를
         // 통해 appState 를 강제로 .authenticated 로 전환해 현재 화면을 덮어쓰므로 발송 금지.
-        // (RootView 의 scenePhase 핸들러 가드와 동일한 규칙)
-        if store?.state.appState == .authenticated {
+        if appState == .authenticated {
             store?.send(.refreshHomeData)
         }
     }
@@ -57,12 +71,17 @@ class MongleAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         let userInfo = response.notification.request.content.userInfo
         if let type = userInfo["type"] as? String {
             switch type {
-            case "ANSWER_REQUEST", "MEMBER_ANSWERED", "NEW_QUESTION", "REMINDER":
-                // REMINDER는 홈으로 보내 오늘의 질문 카드를 즉시 노출.
-                // (답변자는 재촉하기 버튼, 미답변자는 답변 작성 CTA로 자연스럽게 유도.)
+            // 모든 NotificationType (서버 schema 기준) 명시적 처리.
+            // 누락 시 silent fail 방지 — 신규 type 추가 시 컴파일러가 경고하지 않더라도
+            // 이 switch 가 사용자 의도를 명확히 반영하도록 보강.
+            case "NEW_QUESTION", "MEMBER_ANSWERED", "ALL_ANSWERED",
+                 "ANSWER_REQUEST", "ANSWERER_NUDGE", "REMINDER", "BADGE_EARNED":
+                // 모두 홈/오늘 질문 화면으로 보내 사용자가 자연스럽게 답변/재촉으로 이어지게 함.
+                // 세부 라우팅 차별화는 follow-up.
                 store?.send(.openQuestion)
             default:
-                break
+                // 알 수 없는 type 은 안전한 기본 동작 — 홈 진입.
+                store?.send(.openQuestion)
             }
         }
         completionHandler()

--- a/MongleData/Sources/MongleData/DataSources/Remote/API/APIEndpoint.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/API/APIEndpoint.swift
@@ -632,6 +632,8 @@ enum MoodEndpoint: APIEndpoint {
 enum NotificationEndpoint: APIEndpoint {
     /// GET /notifications?limit=N&group_id=ID
     case getAll(limit: Int, familyId: String?)
+    /// GET /notifications/unread-count — OS 배지 동기화용 (50건 캡 우회, MG-54)
+    case unreadCount
     /// PATCH /notifications/{id}/read
     case markAsRead(id: String)
     /// PATCH /notifications/read-all?group_id=ID
@@ -644,6 +646,7 @@ enum NotificationEndpoint: APIEndpoint {
     var path: String {
         switch self {
         case .getAll: return "/notifications"
+        case .unreadCount: return "/notifications/unread-count"
         case .markAsRead(let id): return "/notifications/\(id)/read"
         case .markAllAsRead: return "/notifications/read-all"
         case .delete(let id): return "/notifications/\(id)"
@@ -653,7 +656,7 @@ enum NotificationEndpoint: APIEndpoint {
 
     var method: HTTPMethod {
         switch self {
-        case .getAll: return .get
+        case .getAll, .unreadCount: return .get
         case .markAsRead, .markAllAsRead: return .patch
         case .delete, .deleteAll: return .delete
         }

--- a/MongleData/Sources/MongleData/Repositories/NotificationRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/NotificationRepository.swift
@@ -18,6 +18,12 @@ final class NotificationRepository: NotificationRepositoryProtocol {
         return response.notifications.compactMap { $0.toDomain() }
     }
 
+    func getUnreadCount() async throws -> Int {
+        struct Response: Decodable { let count: Int }
+        let response: Response = try await apiClient.request(NotificationEndpoint.unreadCount)
+        return response.count
+    }
+
     func markAsRead(id: UUID) async throws -> Domain.Notification {
         let dto: NotificationDTO = try await apiClient.request(NotificationEndpoint.markAsRead(id: id.uuidString))
         guard let notification = dto.toDomain() else { throw APIError.decodingError("notification mapping failed") }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationFeature.swift
@@ -16,6 +16,12 @@ public typealias MongleNotification = Domain.Notification
 @Reducer
 public struct NotificationFeature {
 
+    private enum CancelID: Hashable {
+        /// markRead/delete 등이 빠르게 연쇄될 때 syncAppIconBadge 가 N개 동시 in-flight 가
+        /// 되며 마지막 응답이 stale 한 카운트로 OS 배지를 덮어쓰는 race 방지.
+        case badgeSync
+    }
+
     // MARK: - Mode
 
     public enum Mode: Equatable, Sendable {
@@ -208,6 +214,7 @@ public struct NotificationFeature {
                         await send(.delegate(.navigateToQuestion(markAsReadId: nil)))
                     }
                 }
+                .cancellable(id: CancelID.badgeSync, cancelInFlight: true)
 
             case .markAsRead(let notification):
                 // Optimistic update
@@ -227,6 +234,7 @@ public struct NotificationFeature {
                     _ = try? await notificationRepository.markAsRead(id: notification.id)
                     await Self.syncAppIconBadge(notificationRepository)
                 }
+                .cancellable(id: CancelID.badgeSync, cancelInFlight: true)
 
             case .markAllAsRead:
                 let scopeFamilyId = state.mode.scopeFamilyId
@@ -249,6 +257,7 @@ public struct NotificationFeature {
                     _ = try? await notificationRepository.markAllAsRead(familyId: scopeFamilyId)
                     await Self.syncAppIconBadge(notificationRepository)
                 }
+                .cancellable(id: CancelID.badgeSync, cancelInFlight: true)
 
             case .deleteNotification(let notification):
                 state.notifications = state.notifications.filter { $0.id != notification.id }
@@ -256,6 +265,7 @@ public struct NotificationFeature {
                     _ = try? await notificationRepository.delete(id: notification.id)
                     await Self.syncAppIconBadge(notificationRepository)
                 }
+                .cancellable(id: CancelID.badgeSync, cancelInFlight: true)
 
             case .deleteAll:
                 let scopeFamilyId = state.mode.scopeFamilyId
@@ -269,6 +279,7 @@ public struct NotificationFeature {
                     _ = try? await notificationRepository.deleteAll(familyId: scopeFamilyId)
                     await Self.syncAppIconBadge(notificationRepository)
                 }
+                .cancellable(id: CancelID.badgeSync, cancelInFlight: true)
 
             case .dismissError:
                 state.errorMessage = nil
@@ -307,9 +318,13 @@ public struct NotificationFeature {
     /// 인앱 알림 mutation(읽음/삭제) 직후 OS 앱 아이콘 배지를 전체 그룹 합산
     /// 미읽음 수로 동기화한다. NotificationFeature.state.notifications 는
     /// .filtered 모드에서는 단일 그룹 데이터만 들고 있어 자체 계산이 부정확하므로,
-    /// `familyId: nil` 로 전체 그룹을 다시 한 번 조회한다.
-    /// (limit 50 cap — 50건 초과 누적은 follow-up 으로 서버 unread-count 라우트 노출)
+    /// 서버의 unread-count 라우트(MG-54)를 사용해 정확한 수치 조회 (50건 캡 제거).
+    /// 서버 호출 실패 시 기존 getNotifications limit 50 fallback 으로 점진 동작.
     private static func syncAppIconBadge(_ repository: NotificationRepositoryProtocol) async {
+        if let unread = try? await repository.getUnreadCount() {
+            try? await UNUserNotificationCenter.current().setBadgeCount(unread)
+            return
+        }
         let all = (try? await repository.getNotifications(limit: 50, familyId: nil)) ?? []
         let unread = all.filter { !$0.isRead }.count
         try? await UNUserNotificationCenter.current().setBadgeCount(unread)

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -499,6 +499,10 @@ extension RootFeature {
                 case .login(.delegate(.loggedIn(let user, let providerType, let needsConsent, let requiredConsents, let legalVersions))):
                     state.loginProviderType = providerType
                     state.currentUser = user
+                    // 새 계정 로그인 시 unauthenticated 상태에서 도착한 푸시 tap 으로
+                    // 설정된 pendingOpenQuestion 이 잔존하면 사용자 B 의 첫 로딩에서
+                    // 의도치 않은 질문 화면 자동 진입이 발생. 명시 cleanup.
+                    state.pendingOpenQuestion = false
                     if needsConsent {
                         // 동의 화면으로 라우팅 — 동의 완료 후 .consent(.delegate(.completed))
                         // 에서 checkAuthResponse 로 이어진다.


### PR DESCRIPTION
## Jira
- [MG-55](https://ycompany.atlassian.net/browse/MG-55)

## Related
- 선행: MG-54 (Server unread-count 라우트, PR-Server #47)
- 1차 audit MG-39 (PR #59) — 배지 동기화

## Summary
- didReceive type switch 완전성 + safe fallback
- willPresent appState 가드
- didFailToRegister 핸들러
- login.loggedIn pendingOpenQuestion 정리
- syncAppIconBadge cancellable + unread-count API
- BUILD SUCCEEDED

## Test plan
- [ ] 신규 NotificationType 도착 → openQuestion 라우팅
- [ ] consent/emailLogin 화면 push → 배너 X, 리스트 O
- [ ] 다른 계정 로그인 시 pendingOpenQuestion 자동 이행 X
- [ ] markAsRead 연속 호출 시 OS 배지 마지막 호출만 적용 (race 차단)
- [ ] 50건+ 누적 → 정확한 unread 표시 (unread-count API 검증)
- [ ] APNs 등록 실패 시 CloudWatch 로그

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)