### PR TITLE
fix(ios): modal/navigation race (MG-56)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/Ext/MainTab+Action.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/Ext/MainTab+Action.swift
@@ -49,6 +49,8 @@ extension MainTabFeature {
 
         // MARK: Answer Heart Popup
         case dismissAnswerHeartPopup
+        /// answerSubmitted 후 NavigationStack pop 완료를 기다린 뒤 popup + toast 동시 표시.
+        case showAnswerHeartAndToast
 
         // MARK: Peer Answer
         case showPeerAnswer(memberName: String, questionText: String, peerAnswer: String, myAnswer: String, monggleColor: Color, peerAnswerTime: String, myAnswerTime: String)

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/Ext/MainTab+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/Ext/MainTab+Reducer.swift
@@ -397,17 +397,15 @@ extension MainTabFeature {
                     state.modal = nil
                     let activeQuestion = state.home.todayQuestion ?? state.home.yesterdayQuestion
                     guard let question = activeQuestion else { return .none }
-                    state.path.append(
-                        .questionDetail(
-                            QuestionDetailFeature.State(
-                                question: question,
-                                currentUser: state.home.currentUser,
-                                familyMembers: state.home.familyMembers,
-                                hearts: state.home.hearts
-                            )
-                        )
-                    )
-                    return .none
+                    let homeSnapshot = state.home
+                    // sheet dismiss 애니메이션(~350ms)과 NavigationStack push 가 같은
+                    // reduce 에서 발생하면 push 가 drop 되거나 navigation bar 가 깨진다.
+                    // questionSheet→navigateToAnswer 경로의 동일 패턴 적용.
+                    return .run { send in
+                        try await Task.sleep(nanoseconds: 350_000_000)
+                        await send(.delegate(.navigateToQuestionDetail(question)))
+                        _ = homeSnapshot
+                    }
 
                 // MARK: - PeerNudge Delegate
 
@@ -522,8 +520,9 @@ extension MainTabFeature {
                         }
                     }
                     state.path.removeLast()
-                    state.showAnswerSubmittedToast = true
-                    state.showAnswerHeartPopup = true
+                    // popup/toast 는 NavigationStack pop 애니메이션 (~350ms) 완료 후 표시.
+                    // 같은 reduce 에서 즉시 켜면 popup overlay 가 pop 진행 중 mount 되어
+                    // 이전 화면 hit-test 차단 + toast 가 popup 에 가려져 사용자가 못 봄.
                     return .merge(
                         .send(.history(.forceReload)),
                         .run { [userRepository] _ in
@@ -531,10 +530,18 @@ extension MainTabFeature {
                             _ = try? await userRepository.update(user)
                         },
                         .run { send in
-                            try await Task.sleep(nanoseconds: 4_000_000_000)
-                            await send(.dismissAnswerSubmittedToast)
+                            try await Task.sleep(nanoseconds: 350_000_000)
+                            await send(.showAnswerHeartAndToast)
                         }
                     )
+
+                case .showAnswerHeartAndToast:
+                    state.showAnswerSubmittedToast = true
+                    state.showAnswerHeartPopup = true
+                    return .run { send in
+                        try await Task.sleep(nanoseconds: 4_000_000_000)
+                        await send(.dismissAnswerSubmittedToast)
+                    }
 
                 case .path(.element(id: _, action: .questionDetail(.delegate(.answerEdited(_, let moodId))))):
                     state.path.removeLast()

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
@@ -368,7 +368,11 @@ public struct QuestionDetailFeature {
                 return .none
 
             case .closeTapped:
+                // 제출 중인 동안 close 입력은 무시 — 사용자가 dismiss 한 뒤 응답이 도착해도
+                // 부모가 path.removeLast 시점이 충돌해 다음 화면이 비정상 표시되는 race 차단.
+                guard !state.isSubmitting else { return .none }
                 state.appError = nil
+                state.editCostPopup = nil
                 return .send(.delegate(.closed))
 
             // MARK: - Internal Actions

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -771,6 +771,9 @@ extension RootFeature {
                         let currentUser = state.mainTab?.home.currentUser
                         let familyMembers = state.mainTab?.home.familyMembers ?? []
                         let hearts = state.mainTab?.home.hearts ?? 0
+                        // 활성 sheet/popup 이 있으면 close 해 navigation push 가 sheet 뒤에
+                        // 숨는 race 를 차단. push 도착 즉시 답변 화면 진입을 위해 모달 우선 정리.
+                        state.mainTab?.modal = nil
                         state.mainTab?.path.removeAll()
                         state.mainTab?.path.append(.questionDetail(QuestionDetailFeature.State(
                             question: question,


### PR DESCRIPTION
[MG-56](https://ycompany.atlassian.net/browse/MG-56)

- PeerAnswer.editAnswer 350ms 패턴
- answerSubmitted pop→popup+toast 직렬화
- openQuestion modal nil
- closeTapped guard isSubmitting

BUILD SUCCEEDED. Closes #72