### PR TITLE
perf(search): 결과 grouping/sorted/DateFormatter 를 reducer 캐시로 이전 (MG-60)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Search/SearchHistoryFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Search/SearchHistoryFeature.swift
@@ -28,6 +28,16 @@ public struct SearchResultItem: Equatable, Identifiable, Sendable {
     public let totalAnswerCount: Int
 }
 
+// MARK: - Grouped Result Section
+// 검색 결과를 날짜별로 사전 그룹핑·정렬한 결과. View 가 매 body 호출마다
+// Dictionary(grouping:) + sorted 를 반복하던 비용을 제거한다. displayLabel 까지
+// Feature 단계에서 포맷해 두므로 카드 렌더링 시 DateFormatter 호출도 사라진다.
+public struct SearchResultSection: Equatable, Identifiable, Sendable {
+    public let id: TimeInterval     // 그날 0시의 timeIntervalSince1970
+    public let displayLabel: String // "4월 26일 · 오늘" 등 사전 포맷된 라벨
+    public let items: [SearchResultItem]
+}
+
 // MARK: - Feature
 
 @Reducer
@@ -37,6 +47,11 @@ public struct SearchHistoryFeature {
     public struct State: Equatable {
         public var query: String = ""
         public var results: [SearchResultItem] = []
+        /// View 가 사용할 사전 그룹핑된 결과. results 변경 시점에만 reducer 가 갱신.
+        public var groupedResults: [SearchResultSection] = []
+        /// 카드 ID → "이 카드 다음에 광고 배너를 끼워라" 인 카드 ID 집합.
+        /// 매 body 호출마다 globalIndex 를 카운트하던 비용 + Dictionary[String:Int] lookup 을 Set.contains 로 단순화.
+        public var adAnchorIds: Set<String> = []
         public var isLoading: Bool = false
         public var showMinLengthHint: Bool = false
         public var errorMessage: String? = nil
@@ -48,6 +63,47 @@ public struct SearchHistoryFeature {
         public var resultCount: Int { results.count }
 
         public init() {}
+    }
+
+    // MARK: - 정적 Formatter
+    // DateFormatter 인스턴스 생성은 비싼 작업. 카드/섹션마다 신규 할당하지 않고 재사용.
+    private static let sectionDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = .current
+        f.setLocalizedDateFormatFromTemplate("MMMd")
+        return f
+    }()
+
+    /// 정렬된 results 를 1회 순회하며 광고 삽입 위치(매 11번째 + 마지막)를 사전 계산.
+    private static func makeAdAnchorIds(from results: [SearchResultItem]) -> Set<String> {
+        var anchors: Set<String> = []
+        let total = results.count
+        for (i, r) in results.enumerated() {
+            if (i + 1) % 11 == 0 || i + 1 == total {
+                anchors.insert(r.id)
+            }
+        }
+        return anchors
+    }
+
+    private static func makeSections(from results: [SearchResultItem]) -> [SearchResultSection] {
+        let calendar = Calendar.current
+        var grouped: [TimeInterval: [SearchResultItem]] = [:]
+        for r in results {
+            let key = calendar.startOfDay(for: r.date).timeIntervalSince1970
+            grouped[key, default: []].append(r)
+        }
+        return grouped
+            .sorted { $0.key > $1.key }
+            .map { (key, items) in
+                let date = Date(timeIntervalSince1970: key)
+                let base = sectionDateFormatter.string(from: date)
+                let label: String
+                if calendar.isDateInToday(date)       { label = "\(base) · 오늘" }
+                else if calendar.isDateInYesterday(date) { label = "\(base) · 어제" }
+                else                                  { label = base }
+                return SearchResultSection(id: key, displayLabel: label, items: items)
+            }
     }
 
     public enum Action: Equatable, Sendable {
@@ -114,6 +170,8 @@ public struct SearchHistoryFeature {
                 let trimmed = query.trimmingCharacters(in: .whitespaces)
                 guard trimmed.count >= 2 else {
                     state.results = []
+                    state.groupedResults = []
+                    state.adAnchorIds = []
                     return .none
                 }
                 // 아직 히스토리 로딩 중이라면 결과를 비우지 않고 대기 (historyLoaded 후 재검색됨)
@@ -163,6 +221,8 @@ public struct SearchHistoryFeature {
 
                 results.sort { $0.date > $1.date }
                 state.results = results
+                state.groupedResults = Self.makeSections(from: results)
+                state.adAnchorIds = Self.makeAdAnchorIds(from: results)
                 return .none
 
             case .setError(let message):
@@ -173,6 +233,8 @@ public struct SearchHistoryFeature {
             case .reset:
                 state.query = ""
                 state.results = []
+                state.groupedResults = []
+                state.adAnchorIds = []
                 state.allHistory = []
                 state.loadedFamilyId = nil
                 state.isLoading = false
@@ -188,6 +250,8 @@ public struct SearchHistoryFeature {
                 guard state.loadedFamilyId != familyId else { return .none }
                 state.allHistory = []
                 state.results = []
+                state.groupedResults = []
+                state.adAnchorIds = []
                 state.loadedFamilyId = familyId
                 guard familyId != nil else {
                     state.isLoading = false

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Search/SearchHistoryView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Search/SearchHistoryView.swift
@@ -109,69 +109,51 @@ public struct SearchHistoryView: View {
                 .padding(.top, MongleSpacing.md)
                 .padding(.bottom, MongleSpacing.sm)
 
-                // Date-grouped results
-                let grouped = Dictionary(grouping: store.results) { $0.date.dayKey }
-                let sortedGroups = grouped.keys.sorted(by: >)
-                let total = store.results.count
-                let globalIndices: [String: Int] = {
-                    var idx = 0
-                    var dict: [String: Int] = [:]
-                    for dayKey in sortedGroups {
-                        for item in (grouped[dayKey] ?? []) {
-                            dict[item.id] = idx
-                            idx += 1
-                        }
-                    }
-                    return dict
-                }()
+                // 사전 그룹핑된 섹션을 그대로 소비. body 내 Dictionary(grouping:)·sorted·DateFormatter 비용 제거.
+                let sections = store.groupedResults
+                let trimmedQuery = store.query.trimmingCharacters(in: .whitespaces)
+                let adAnchors = store.adAnchorIds
 
-                ForEach(sortedGroups, id: \.self) { dayKey in
-                    let items = grouped[dayKey] ?? []
-                    if let firstItem = items.first {
-                        // Date header
-                        HStack(spacing: 6) {
-                            Image(systemName: "calendar")
-                                .font(.system(size: 11))
-                                .foregroundColor(MongleColor.textHint)
-                            Text(firstItem.date.displayLabel)
-                                .font(MongleFont.label())
-                                .fontWeight(.semibold)
-                                .foregroundColor(MongleColor.textHint)
-                            Spacer()
-                        }
+                ForEach(sections) { section in
+                    // Date header
+                    HStack(spacing: 6) {
+                        Image(systemName: "calendar")
+                            .font(.system(size: 11))
+                            .foregroundColor(MongleColor.textHint)
+                        Text(section.displayLabel)
+                            .font(MongleFont.label())
+                            .fontWeight(.semibold)
+                            .foregroundColor(MongleColor.textHint)
+                        Spacer()
+                    }
+                    .padding(.horizontal, MongleSpacing.md)
+                    .padding(.bottom, MongleSpacing.xs)
+
+                    // Cards for this date
+                    ForEach(section.items) { result in
+                        SearchResultCard(
+                            result: result,
+                            query: trimmedQuery
+                        )
                         .padding(.horizontal, MongleSpacing.md)
                         .padding(.bottom, MongleSpacing.xs)
 
-                        // Cards for this date
-                        ForEach(items) { result in
-                            SearchResultCard(
-                                result: result,
-                                query: store.query.trimmingCharacters(in: .whitespaces)
-                            )
-                            .padding(.horizontal, MongleSpacing.md)
-                            .padding(.bottom, MongleSpacing.xs)
-
-                            if shouldShowAd(after: globalIndices[result.id] ?? 0, total: total) {
-                                #if os(iOS)
-                                AdBannerSection()
-                                    .padding(.horizontal, 20)
-                                    .padding(.bottom, MongleSpacing.sm)
-                                #endif
-                            }
+                        if adAnchors.contains(result.id) {
+                            #if os(iOS)
+                            AdBannerSection()
+                                .padding(.horizontal, 20)
+                                .padding(.bottom, MongleSpacing.sm)
+                            #endif
                         }
-
-                        Spacer().frame(height: MongleSpacing.xxs)
                     }
+
+                    Spacer().frame(height: MongleSpacing.xxs)
                 }
 
                 Spacer().frame(height: MongleSpacing.xl)
             }
         }
         .scrollDismissesKeyboard(.immediately)
-    }
-
-    private func shouldShowAd(after index: Int, total: Int) -> Bool {
-        (index + 1) % 11 == 0 || index + 1 == total
     }
 
     // MARK: - Empty State
@@ -342,25 +324,7 @@ private func colorIndexFromMoodId(_ moodId: String?) -> Int {
     }
 }
 
-private extension Date {
-    var dayKey: TimeInterval {
-        Calendar.current.startOfDay(for: self).timeIntervalSince1970
-    }
-
-    var displayLabel: String {
-        let cal = Calendar.current
-        let formatter = DateFormatter()
-        formatter.locale = .current
-        formatter.setLocalizedDateFormatFromTemplate("MMMd")
-        let base = formatter.string(from: self)
-        if cal.isDateInToday(self) {
-            return "\(base) · 오늘"
-        } else if cal.isDateInYesterday(self) {
-            return "\(base) · 어제"
-        }
-        return base
-    }
-}
+// 날짜 그룹 라벨/dayKey 는 SearchHistoryFeature 에서 사전 계산 (DateFormatter 재사용 + body 부담 제거).
 
 // UIColor hex init for AttributedString
 private extension UIColor {


### PR DESCRIPTION
## Jira
- [MG-60](https://ycompany.atlassian.net/browse/MG-60)

## Related
- 동일 패턴 시리즈: MG-59 (History) #78, MG-61 (Notification)

## Summary
- SearchHistoryView 의 body-side Dictionary grouping + sorted + DateFormatter() 신규 생성을 모두 제거 (100건 기준 hash 100 + sort + formatter 100 → 0)
- 신규 `SearchResultSection` 구조체로 사전 그룹핑·정렬·displayLabel 포맷 완료된 데이터를 State 에 보관
- 광고 인덱스를 `adAnchorIds: Set<String>` 사전계산으로 단순화 (Set.contains O(1))
- `sectionDateFormatter` static let 인스턴스 1개 재사용

## Test plan
- [ ] 2글자 미만/2글자 이상 검색어 입력 시 hint·결과 정상 전환
- [ ] 결과 0건/1건/다건의 그룹 헤더 라벨 (오늘/어제/날짜)
- [ ] 검색 결과 카드의 highlighted query (한글 NFC/NFD 매칭) 정상
- [ ] 광고 배너가 11번째·마지막 카드 뒤에 노출 (Release 빌드)
- [ ] 그룹 전환 시 캐시 무효화 (`reset` / `setActiveFamily`)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)