### PR TITLE
refactor(home): 알림 권한 effect cancellable + race 차단 (MG-62)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Home/HomeFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Home/HomeFeature.swift
@@ -13,6 +13,14 @@ import UIKit
 
 @Reducer
 public struct HomeFeature {
+
+    private enum CancelID: Hashable {
+        /// 알림 권한 요청 effect 의 in-flight 중복 차단.
+        /// 빠른 이중 탭 시 requestAuthorization + registerForRemoteNotifications 가
+        /// 두 번 fire 되어 device token callback 이 중복 발생하는 race 를 막는다.
+        case requestNotifAuth
+    }
+
     @ObservableState
     public struct State: Equatable {
         public var todayQuestion: Question?
@@ -300,6 +308,7 @@ public struct HomeFeature {
                         UIApplication.shared.registerForRemoteNotifications()
                     }
                 }
+                .cancellable(id: CancelID.requestNotifAuth, cancelInFlight: true)
 
             case .notificationPermissionSkipped:
                 if let family = state.family {


### PR DESCRIPTION
## Jira
- [MG-62](https://ycompany.atlassian.net/browse/MG-62)

## Related (Home 화면 성능 분석 시리즈)
- MG-63 P0 — MongleScene Timer 부하 완화
- MG-64 P2 — homeViewSection reducer 캐시 + closure 단일화
- MG-65 P1 — Tuple → MongleMember struct 마이그레이션
- 권장 머지 순서: **#83 (MG-62) → MG-63 → MG-64 → MG-65**

## Summary
- `.notificationPermissionAllowed` effect 에 `CancelID.requestNotifAuth` + `.cancellable(cancelInFlight: true)` 적용
- 빠른 이중 탭 시 `requestAuthorization` + `registerForRemoteNotifications` 가 두 번 fire 되어 device token callback 이 중복 발생하는 race 차단

## Test plan
- [x] 빌드 성공 (Debug, iPhone 16 Simulator)
- [ ] 시뮬레이터: 알림 권한 팝업에서 빠르게 두 번 탭 → 권한 시스템 다이얼로그 1회만 호출되는지
- [ ] 실기기: device token registration 이 1회만 발생하는지

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)