### PR TITLE
refactor(home): HomeView EquatableView 화 — 부모 무관 상태 변화 재평가 차단 (MG-64)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Home/HomeView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Home/HomeView.swift
@@ -10,7 +10,7 @@ import Domain
 
 // MARK: - TopBar State Models
 
-struct HomeTopBarState {
+struct HomeTopBarState: Equatable {
   var streakDays: Int
   var groupName: String
   var groupId: UUID?
@@ -50,7 +50,7 @@ struct HomeTopBarState {
   )
 }
 
-struct TopBarQuestion: Identifiable {
+struct TopBarQuestion: Identifiable, Equatable {
   let id: UUID
   let text: String
   let isAnswered: Bool
@@ -75,7 +75,13 @@ struct HomeViewActions {
 
 // MARK: - Main View
 
-struct HomeView: View {
+/// HomeView 가 EquatableView 로 wrapping 될 수 있도록 Equatable 채택.
+/// SwiftUI 는 Equatable View 의 == 가 true 일 때 body 평가를 skip 한다.
+/// 그 결과 부모(MainTabView) 의 무관한 상태 변화(예: TopBar dropdown 토글) 가
+/// HomeView 본문 + MongleSceneView 까지 invalidate 시키는 비용을 차단한다.
+/// 클로저 멤버(actions)는 비교에서 제외 — closure identity 가 매번 새로 생성되므로
+/// 비교에 포함하면 항상 false 가 되어 skip 효과가 사라진다.
+struct HomeView: View, Equatable {
     let topBarState: HomeTopBarState
     let hasCurrentUserAnswered: Bool
     let hasCurrentUserSkipped: Bool
@@ -85,6 +91,24 @@ struct HomeView: View {
     var showNotificationPermission: Bool = false
 
     @State private var showGroupDropdown = false
+
+    static func == (lhs: HomeView, rhs: HomeView) -> Bool {
+        guard lhs.topBarState == rhs.topBarState,
+              lhs.hasCurrentUserAnswered == rhs.hasCurrentUserAnswered,
+              lhs.hasCurrentUserSkipped == rhs.hasCurrentUserSkipped,
+              lhs.currentUserName == rhs.currentUserName,
+              lhs.showNotificationPermission == rhs.showNotificationPermission,
+              lhs.members.count == rhs.members.count
+        else { return false }
+        // 튜플 배열은 Equatable 자동 합성이 안 되므로 element-wise 비교.
+        // (Swift 의 tuple == 는 arity ≤ 6 + 모든 element Equatable 일 때 사용 가능)
+        for (l, r) in zip(lhs.members, rhs.members) {
+            if l.name != r.name || l.color != r.color || l.hasAnswered != r.hasAnswered || l.hasSkipped != r.hasSkipped {
+                return false
+            }
+        }
+        return true
+    }
 
     init(
         topBarState: HomeTopBarState = .preview,

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
@@ -194,6 +194,7 @@ struct MainTabView: View {
             ),
             showNotificationPermission: store.home.showNotificationPermission
         )
+        .equatable()
         .mongleErrorToast(
             error: store.home.appError,
             onDismiss: { store.send(.home(.dismissError)) }


### PR DESCRIPTION
## Jira
- [MG-64](https://ycompany.atlassian.net/browse/MG-64)

## Related (Home 화면 성능 분석 시리즈)
- MG-62 P3 — 알림 권한 cancellable (#84)
- MG-63 P0 — MongleScene Timer 부하 완화 (#86)
- MG-65 P1 — Tuple → MongleMember struct 마이그레이션 (예정)
- 권장 머지 순서: **#84 → #86 → #88 (MG-64) → MG-65**

## Summary
- \`HomeTopBarState\` / \`TopBarQuestion\` Equatable 채택
- \`HomeView\` Equatable 채택 + closure 만 제외한 manual ==
- \`MainTabView\` HomeView 호출지에 \`.equatable()\` 모디파이어 추가

## 효과
- HomeView 의 non-closure 입력이 동일하면 SwiftUI 가 body 평가를 skip
- TopBar dropdown toggle 같은 무관한 부모 @State 변화에 의한 MongleSceneView 재평가 차단

## 후속
- HomeViewActions closure 12 → 1 dispatcher 단일화는 호출지 변경 범위가 넓어 별도 PR

## Test plan
- [x] 빌드 성공 (Debug, iPhone 16 Simulator)
- [ ] 시뮬레이터: 그룹 dropdown 토글 시 캐릭터 hop 애니메이션 끊김 없음
- [ ] 답변/패스 상태 변경 시 HomeView 즉시 갱신
- [ ] 그룹 전환 시 HomeView 갱신

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)