### PR TITLE
refactor(home): Home 멤버 모델 Tuple → MongleMember struct 마이그레이션 (MG-65)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Design/Components.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Design/Components.swift
@@ -1271,12 +1271,38 @@ public struct MongleView: View {
     }
 }
 
+// MARK: - Mongle Member (Home / Scene 멤버 모델)
+
+/// Home 화면 캐릭터 노드의 단일 모델.
+///
+/// 이전에는 `(name: String, color: Color, hasAnswered: Bool, hasSkipped: Bool)` tuple 배열로
+/// 주고받았으나, 이는 (1) Equatable 자동 합성이 안 되어 SwiftUI 의 view diff 에서 비효율,
+/// (2) Identifiable 미준수로 ForEach 의 id 추출 클로저가 element 마다 호출,
+/// (3) 신규 필드 추가 시 명명 충돌·초기화 누락 위험이 있었다.
+///
+/// 명명된 struct 로 끌어올려 SwiftUI / TCA 양쪽 모두 1급 시민으로 다룰 수 있게 한다.
+public struct MongleMember: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let name: String
+    public let color: Color
+    public let hasAnswered: Bool
+    public let hasSkipped: Bool
+
+    public init(id: UUID, name: String, color: Color, hasAnswered: Bool, hasSkipped: Bool) {
+        self.id = id
+        self.name = name
+        self.color = color
+        self.hasAnswered = hasAnswered
+        self.hasSkipped = hasSkipped
+    }
+}
+
 // MARK: - Mongle Scene (구역 내 이동 + 충돌 감지)
 
 public struct MongleSceneView: View {
     public var hasCurrentUserAnswered: Bool = false
     public var hasCurrentUserSkipped: Bool = false
-    public var members: [(name: String, color: Color, hasAnswered: Bool, hasSkipped: Bool)]
+    public var members: [MongleMember]
     public var currentUserName: String?
     public var onViewAnswer: (String) -> Void = { _ in }
     public var onNudge: (String) -> Void = { _ in }
@@ -1298,17 +1324,17 @@ public struct MongleSceneView: View {
     /// NavigationStack push 등으로 onDisappear 가 즉시 fire 되지 않는 케이스에서도 유효.
     @Environment(\.scenePhase) private var scenePhase
 
-    private static let defaultMemberData: [(String, Color, Bool, Bool)] = [
-        ("Dad", .orange, true, false),
-        ("Mom", .green, false, false),
-        ("Lily", .yellow, true, false),
-        ("Ben", .blue, false, false),
-        ("Alex", .pink, true, false)
+    private static let defaultMemberData: [MongleMember] = [
+        MongleMember(id: UUID(), name: "Dad",  color: .orange, hasAnswered: true,  hasSkipped: false),
+        MongleMember(id: UUID(), name: "Mom",  color: .green,  hasAnswered: false, hasSkipped: false),
+        MongleMember(id: UUID(), name: "Lily", color: .yellow, hasAnswered: true,  hasSkipped: false),
+        MongleMember(id: UUID(), name: "Ben",  color: .blue,   hasAnswered: false, hasSkipped: false),
+        MongleMember(id: UUID(), name: "Alex", color: .pink,   hasAnswered: true,  hasSkipped: false)
     ]
 
     public init(hasCurrentUserAnswered: Bool = false,
                 hasCurrentUserSkipped: Bool = false,
-                members: [(name: String, color: Color, hasAnswered: Bool, hasSkipped: Bool)] = [],
+                members: [MongleMember] = [],
                 currentUserName: String? = nil,
                 onViewAnswer: @escaping (String) -> Void = { _ in },
                 onNudge: @escaping (String) -> Void = { _ in },
@@ -1326,8 +1352,9 @@ public struct MongleSceneView: View {
         self.onAnswerFirstToNudge = onAnswerFirstToNudge
     }
 
-    private var effectiveMembers: [(String, Color, Bool, Bool)] {
-        members.isEmpty ? Self.defaultMemberData : members.map { ($0.name, $0.color, $0.hasAnswered, $0.hasSkipped) }
+    private var effectiveMembers: [MongleMember] {
+        // 빈 배열이면 폴백, 아니면 입력 배열 그대로 사용 (재할당 0회)
+        members.isEmpty ? Self.defaultMemberData : members
     }
 
     public var body: some View {
@@ -1375,27 +1402,32 @@ public struct MongleSceneView: View {
                     timer = nil
                 }
             }
-            .onChange(of: members.map { $0.name }) { _, _ in
+            // 멤버 배열 변화 1개의 onChange 로 통합 (이전: name/hasAnswered/hasSkipped/color
+            // 4중 onChange + 매 평가마다 members.map 임시배열 4개 생성).
+            // 핸들러 안에서는 [String: MongleMember] dict 인덱스로 O(1) 매치하여
+            // 이전의 nested O(N²) linear search 제거.
+            .onChange(of: members) { oldMembers, newMembers in
                 guard geo.size.width > 0, geo.size.height > 0 else { return }
-                initMongles(size: geo.size)
-            }
-            .onChange(of: members.map { $0.hasAnswered }) { _, _ in
+
+                // 이름 집합이 바뀌면 시뮬레이션 자체를 재초기화 (가족 구성원 변경)
+                let oldNames = Set(oldMembers.map { $0.name })
+                let newNames = Set(newMembers.map { $0.name })
+                if oldNames != newNames {
+                    initMongles(size: geo.size)
+                    return
+                }
+
+                // 동일 멤버라면 상태(answer/skip/color) 만 업데이트
+                let lookup = Dictionary(uniqueKeysWithValues: newMembers.map { ($0.name, $0) })
                 for i in mongles.indices {
-                    if let member = members.first(where: { $0.name == mongles[i].name }) {
+                    guard let member = lookup[mongles[i].name] else { continue }
+                    if mongles[i].hasAnswered != member.hasAnswered {
                         mongles[i].hasAnswered = member.hasAnswered
                     }
-                }
-            }
-            .onChange(of: members.map { $0.hasSkipped }) { _, _ in
-                for i in mongles.indices {
-                    if let member = members.first(where: { $0.name == mongles[i].name }) {
+                    if mongles[i].hasSkipped != member.hasSkipped {
                         mongles[i].hasSkipped = member.hasSkipped
                     }
-                }
-            }
-            .onChange(of: members.map { $0.color }) { _, _ in
-                for i in mongles.indices {
-                    if let member = members.first(where: { $0.name == mongles[i].name }) {
+                    if mongles[i].color != member.color {
                         mongles[i].color = member.color
                     }
                 }
@@ -1411,7 +1443,7 @@ public struct MongleSceneView: View {
     private func initMongles(size: CGSize) {
         guard size.width > 0, size.height > 0 else { return }
         var placed: [CGPoint] = []
-        mongles = effectiveMembers.map { name, color, hasAnswered, hasSkipped in
+        mongles = effectiveMembers.map { member in
             var pos = randomPos(size: size)
             for _ in 0..<30 {
                 let overlaps = placed.contains { hypot(pos.x - $0.x, pos.y - $0.y) < collisionRadius }
@@ -1420,10 +1452,10 @@ public struct MongleSceneView: View {
             }
             placed.append(pos)
             return MongleCharacter(
-                name: name,
-                color: color,
-                hasAnswered: hasAnswered,
-                hasSkipped: hasSkipped,
+                name: member.name,
+                color: member.color,
+                hasAnswered: member.hasAnswered,
+                hasSkipped: member.hasSkipped,
                 position: pos,
                 targetPosition: randomPos(size: size)
             )

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Home/HomeView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Home/HomeView.swift
@@ -85,7 +85,7 @@ struct HomeView: View, Equatable {
     let topBarState: HomeTopBarState
     let hasCurrentUserAnswered: Bool
     let hasCurrentUserSkipped: Bool
-    let members: [(name: String, color: Color, hasAnswered: Bool, hasSkipped: Bool)]
+    let members: [MongleMember]
     var currentUserName: String?
     var actions: HomeViewActions
     var showNotificationPermission: Bool = false
@@ -114,7 +114,7 @@ struct HomeView: View, Equatable {
         topBarState: HomeTopBarState = .preview,
         hasCurrentUserAnswered: Bool = false,
         hasCurrentUserSkipped: Bool = false,
-        members: [(name: String, color: Color, hasAnswered: Bool, hasSkipped: Bool)] = [],
+        members: [MongleMember] = [],
         currentUserName: String? = nil,
         actions: HomeViewActions = HomeViewActions(),
         showNotificationPermission: Bool = false

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
@@ -148,12 +148,13 @@ struct MainTabView: View {
 
     private var homeViewSection: some View {
         let currentUserId = store.home.currentUser?.id
-        let memberData: [(name: String, color: Color, hasAnswered: Bool, hasSkipped: Bool)] = store.home.familyMembers
+        let memberData: [MongleMember] = store.home.familyMembers
             .enumerated()
             .map { index, user in
                 let isCurrentUser = user.id == currentUserId
                 let moodId = isCurrentUser ? (store.previewMoodId ?? store.currentUserMoodId ?? user.moodId) : user.moodId
-                return (
+                return MongleMember(
+                    id: user.id,
                     name: user.name,
                     color: Self.monggleColor(for: moodId, fallback: index),
                     hasAnswered: store.home.memberAnswerStatus[user.id] ?? false,


### PR DESCRIPTION
## Jira
- [MG-65](https://ycompany.atlassian.net/browse/MG-65)

## Related (Home 화면 성능 분석 시리즈)
- MG-62 P3 — 알림 권한 cancellable (#84)
- MG-63 P0 — MongleScene Timer 부하 완화 (#86)
- MG-64 P2 — HomeView Equatable 화 (#88)
- 권장 머지 순서: **#84 → #86 → #88 → #90 (MG-65, 본 PR)**
- 가장 광범위한 변경 (Components.swift / HomeView.swift / MainTabView.swift) — 다른 PR 머지 후 본 PR rebase 권장

## Summary
- \`MongleMember: Identifiable, Equatable, Sendable\` struct 신설 (Components.swift)
- 모든 호출지 \`[(...)]\` tuple → \`[MongleMember]\` 마이그레이션
- 4중 onChange → 단일 \`.onChange(of: members)\` 통합 + dict O(1) 매치

## 효과
- body 평가당 임시 element 생성: \`4N\` → \`0\`
- onChange 핸들러 비용: \`O(N²)\` → \`O(N)\`
- ForEach id 추출 클로저 호출: \`N회/diff\` → \`0\` (Identifiable 인라인)
- effectiveMembers 정상 분기 재할당 0회
- 모델 확장 시 tuple 명명 충돌 위험 0

## Test plan
- [x] 빌드 성공 (Debug, iPhone 16 Simulator)
- [ ] 시뮬레이터: 가족 멤버 추가/제거 시 시뮬레이션 재초기화
- [ ] 시뮬레이터: 멤버 답변/패스 시 캐릭터 뱃지 갱신
- [ ] 시뮬레이터: 본인 mood 변경 시 캐릭터 색상 즉시 갱신
- [ ] preview 동작 확인 (defaultMemberData 폴백)

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)