### PR TITLE
refactor(mood): MoodOption indexById/colorById 정적 dict + 단일 color(for:) 진입점 (MG-66)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Design/Components.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Design/Components.swift
@@ -812,6 +812,28 @@ public struct MoodOption: Identifiable, Equatable {
         MoodOption(id: "sad",     emoji: "😢", label: L10n.tr("mood_sad"),     color: MongleColor.monggleBlue),
         MoodOption(id: "tired",   emoji: "😴", label: L10n.tr("mood_tired"),   color: MongleColor.monggleOrange),
     ]
+
+    /// moodId → defaults 인덱스 역매핑 캐시.
+    /// 호출지마다 `defaults.firstIndex(where:)` linear scan 을 O(1) lookup 으로 대체.
+    public static let indexById: [String: Int] = Dictionary(
+        uniqueKeysWithValues: defaults.enumerated().map { ($1.id, $0) }
+    )
+
+    /// moodId → Color 매핑 캐시. 화면 내 정의된 5-way switch (PeerNudgeView,
+    /// MainTab+Reducer, MainTabView, NotificationView 등) 를 단일 진입점으로 통합.
+    public static let colorById: [String: Color] = Dictionary(
+        uniqueKeysWithValues: defaults.map { ($0.id, $0.color) }
+    )
+
+    /// moodId 가 nil 이거나 매핑이 없을 때 사용되는 fallback. 기존 화면들이
+    /// monggleYellow / mongglePink 으로 분기되어 일관성이 깨져있던 것을 통일.
+    public static let defaultColor: Color = MongleColor.mongglePink
+
+    /// 단일 진입점 — 모든 moodId → Color 변환은 이 함수를 사용.
+    public static func color(for moodId: String?) -> Color {
+        guard let moodId, let color = colorById[moodId] else { return defaultColor }
+        return color
+    }
 }
 
 /// component/MoodSelector — glass card with row of mood balls

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Peer/PeerNudgeView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Peer/PeerNudgeView.swift
@@ -68,20 +68,12 @@ public struct PeerNudgeView: View {
 
     // MARK: - Empty State (몽글 + 미답변 안내)
 
-    private func monggleColor(for moodId: String?) -> Color {
-        switch moodId {
-        case "happy":  return MongleColor.monggleYellow
-        case "calm":   return MongleColor.monggleGreen
-        case "loved":  return MongleColor.mongglePink
-        case "sad":    return MongleColor.monggleBlue
-        case "tired":  return MongleColor.monggleOrange
-        default:       return MongleColor.monggleYellow
-        }
-    }
+    // 이전: 화면별 5-way switch 중복 (default fallback 도 yellow vs pink 로 화면마다 불일치)
+    // → MoodOption.color(for:) 단일 진입점 사용으로 정책 일관성 확보.
 
     private var emptyState: some View {
         VStack(spacing: 16) {
-            MongleMonggle(color: monggleColor(for: store.memberMoodId), size: 72)
+            MongleMonggle(color: MoodOption.color(for: store.memberMoodId), size: 72)
             VStack(spacing: 4) {
                 Text(L10n.tr("nudge_not_answered", store.memberName))
                     .font(MongleFont.button())

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
@@ -64,9 +64,10 @@ public struct QuestionDetailFeature {
             self.answerText = myAnswer?.content ?? answerText
             self.hearts = hearts
             // 수정 모드: 사용자의 현재 moodId로 초기 선택
+            // (이전: defaults.firstIndex(where:) linear scan → MoodOption.indexById dict O(1))
             if myAnswer != nil,
                let moodId = currentUser?.moodId,
-               let index = MoodOption.defaults.firstIndex(where: { $0.id == moodId }) {
+               let index = MoodOption.indexById[moodId] {
                 self.selectedMoodIndex = index
             } else {
                 self.selectedMoodIndex = selectedMoodIndex
@@ -383,8 +384,9 @@ public struct QuestionDetailFeature {
                 if let myAnswer = data.myAnswer {
                     state.answerText = myAnswer.content
                     // 수정 모드: 사용자의 현재 moodId로 기분 선택 복원
+                    // (이전: defaults.firstIndex(where:) → MoodOption.indexById dict O(1))
                     if let moodId = state.currentUser?.moodId,
-                       let index = MoodOption.defaults.firstIndex(where: { $0.id == moodId }) {
+                       let index = MoodOption.indexById[moodId] {
                         state.selectedMoodIndex = index
                     }
                 }


### PR DESCRIPTION
## Jira
- [MG-66](https://ycompany.atlassian.net/browse/MG-66)

## Related (Q/A flow 성능 분석 시리즈)
- MG-67 P2 — Edit flow performAnswerEdit 헬퍼화 (예정)
- MG-68 P1 — 답변-멤버 매칭 dict O(1) (예정)
- MG-69 P0 — TextField sending + scrollTo 정책 (예정)
- 권장 머지 순서: **#92 (MG-66) → MG-67 → MG-68 → MG-69**

## Summary
- \`MoodOption.indexById\` / \`colorById\` 정적 dict 추가
- \`MoodOption.color(for:)\` 단일 진입점 + \`defaultColor\` (mongglePink) 통일
- QuestionDetailFeature 의 \`firstIndex(where:)\` 2곳 → \`indexById\` O(1)
- PeerNudgeView 의 자체 5-way switch 제거 → \`MoodOption.color(for:)\`

## 후속
- MainTab+Reducer / MainTabView / NotificationView 의 monggleColor 도 동일 패턴으로 통합 — Home PR 시리즈와 파일 충돌 방지를 위해 별도 PR

## Test plan
- [x] 빌드 성공 (Debug, iPhone 16 Simulator)
- [ ] 답변 작성/수정 진입 시 mood 자동 복원 (calm/happy/loved/sad/tired)
- [ ] PeerNudge 화면 캐릭터 색상 — 가족 멤버 mood 별로 정확
- [ ] mood 미설정 (nil) 케이스 → mongglePink (defaultColor)

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)