### PR TITLE
refactor(question-detail): Edit flow performAnswerEdit 헬퍼 추출 (MG-67)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
@@ -244,7 +244,7 @@ public struct QuestionDetailFeature {
 
             case .editCostPopup(.presented(.delegate(.confirmed))):
                 state.editCostPopup = nil
-                guard let existingAnswer = state.myAnswer else { return .none }
+                guard state.myAnswer != nil else { return .none }
                 guard state.hearts >= 1 else {
                     state.appError = .domain(L10n.tr("home_hearts_insufficient"))
                     return .none
@@ -253,30 +253,7 @@ public struct QuestionDetailFeature {
                 // 실패 시 .editRollback 으로 되돌린다.
                 state.hearts -= 1
                 state.isSubmitting = true
-                state.appError = nil
-
-                let editAnswerText = state.answerText.trimmingCharacters(in: .whitespacesAndNewlines)
-                let editUserId = state.currentUser?.id ?? UUID()
-                let editQuestionId = state.question.id
-                let editMoodId = state.selectedMoodIndex.map { MoodOption.defaults[$0].id }
-                let updated = Answer(
-                    id: existingAnswer.id,
-                    dailyQuestionId: editQuestionId,
-                    userId: editUserId,
-                    content: editAnswerText,
-                    imageURL: existingAnswer.imageURL,
-                    createdAt: existingAnswer.createdAt,
-                    updatedAt: Date()
-                )
-                return .run { [answerRepository] send in
-                    do {
-                        let result = try await answerRepository.update(updated, moodId: editMoodId)
-                        await send(.submitAnswerResponse(.success(result)))
-                    } catch {
-                        await send(.editRollback)
-                        await send(.submitAnswerResponse(.failure(AppError.from(error))))
-                    }
-                }
+                return performAnswerEdit(state: &state)
 
             case .editCostPopup(.presented(.delegate(.cancelled))):
                 state.editCostPopup = nil
@@ -325,7 +302,7 @@ public struct QuestionDetailFeature {
                 // 서버 응답으로만 hearts sync. 실패 분기는 .adGrantFailed 로 분리됨.
                 state.hearts = hearts
                 // 광고 시청 완료 → 수정 작업 자동 실행 (다른 광고 보상 기능과 일관)
-                guard let existingAnswer = state.myAnswer else {
+                guard state.myAnswer != nil else {
                     state.isSubmitting = false
                     return .none
                 }
@@ -335,30 +312,7 @@ public struct QuestionDetailFeature {
                     return .none
                 }
                 state.hearts -= 1   // edit 비용 옵티미스틱 차감
-                state.appError = nil
-
-                let editAnswerText = state.answerText.trimmingCharacters(in: .whitespacesAndNewlines)
-                let editUserId = state.currentUser?.id ?? UUID()
-                let editQuestionId = state.question.id
-                let editMoodId = state.selectedMoodIndex.map { MoodOption.defaults[$0].id }
-                let updated = Answer(
-                    id: existingAnswer.id,
-                    dailyQuestionId: editQuestionId,
-                    userId: editUserId,
-                    content: editAnswerText,
-                    imageURL: existingAnswer.imageURL,
-                    createdAt: existingAnswer.createdAt,
-                    updatedAt: Date()
-                )
-                return .run { [answerRepository] send in
-                    do {
-                        let result = try await answerRepository.update(updated, moodId: editMoodId)
-                        await send(.submitAnswerResponse(.success(result)))
-                    } catch {
-                        await send(.editRollback)
-                        await send(.submitAnswerResponse(.failure(AppError.from(error))))
-                    }
-                }
+                return performAnswerEdit(state: &state)
 
             case .editCostPopup:
                 return .none
@@ -420,6 +374,38 @@ public struct QuestionDetailFeature {
         }
         .ifLet(\.$editCostPopup, action: \.editCostPopup) {
             HeartCostPopupFeature()
+        }
+    }
+
+    /// 답변 수정 공통 시퀀스. `editCostPopup(.confirmed)` 와 `.adHeartGranted` 가
+    /// 동일한 update 로직 (locals 추출 + Answer 빌드 + repository.update + rollback)
+    /// 을 가졌던 것을 단일 진입점으로 통합.
+    /// 호출지에서 hearts 검증·옵티미스틱 차감·isSubmitting 플래그를 먼저 셋업한 뒤 호출.
+    private func performAnswerEdit(state: inout State) -> Effect<Action> {
+        guard let existingAnswer = state.myAnswer else { return .none }
+        state.appError = nil
+
+        let editAnswerText = state.answerText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let editUserId = state.currentUser?.id ?? UUID()
+        let editQuestionId = state.question.id
+        let editMoodId = state.selectedMoodIndex.map { MoodOption.defaults[$0].id }
+        let updated = Answer(
+            id: existingAnswer.id,
+            dailyQuestionId: editQuestionId,
+            userId: editUserId,
+            content: editAnswerText,
+            imageURL: existingAnswer.imageURL,
+            createdAt: existingAnswer.createdAt,
+            updatedAt: Date()
+        )
+        return .run { [answerRepository] send in
+            do {
+                let result = try await answerRepository.update(updated, moodId: editMoodId)
+                await send(.submitAnswerResponse(.success(result)))
+            } catch {
+                await send(.editRollback)
+                await send(.submitAnswerResponse(.failure(AppError.from(error))))
+            }
         }
     }
 }


### PR DESCRIPTION
## Jira
- [MG-67](https://ycompany.atlassian.net/browse/MG-67)

## Related (Q/A flow 성능 분석 시리즈)
- MG-66 P3 — MoodOption 정적 dict (#92)
- MG-68 P1 — 답변-멤버 매칭 dict O(1) (예정)
- MG-69 P0 — TextField sending + scrollTo 정책 (예정)
- 권장 머지 순서: **#92 → #94 (MG-67) → MG-68 → MG-69**
- MG-68 과 동일 파일 (QuestionDetailFeature.swift) — 순서대로 머지하면 충돌 없음

## Summary
- \`editCostPopup(.confirmed)\` / \`.adHeartGranted\` 의 동일 update 시퀀스를 \`performAnswerEdit(state:)\` 단일 헬퍼로 추출
- 두 분기 모두 hearts 검증 + 옵티미스틱 -=1 + isSubmitting 셋업 후 \`return performAnswerEdit(state: &state)\` 호출

## 효과
- update 블록 코드: **70줄 → 40줄** (-43%)
- 정책 변경 시 수정 지점: **2곳 → 1곳**

## Test plan
- [x] 빌드 성공
- [ ] 일반 confirm 플로우: 하트 차감 + 답변 수정 정상
- [ ] 광고 시청 플로우 (하트 부족 시): 광고 후 자동 update 실행
- [ ] update 실패 시 editRollback 으로 hearts 복원 (양쪽 분기)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)