### PR TITLE
refactor(question-detail): 답변-멤버 매칭 nested O(F×A) → dict O(1) (MG-68)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
@@ -146,6 +146,9 @@ public struct QuestionDetailFeature {
                 let questionId = state.question.id
                 let currentUserId = state.currentUser?.id
                 let members = state.familyMembers
+                // 멤버 ID 인덱스를 effect 진입 시점에 1회만 구축해 답변-멤버 매칭 비용을
+                // O(F × A) nested linear search 에서 O(F + A) (인덱스 빌드 + O(1) lookup) 로 낮춘다.
+                let memberById = Dictionary(uniqueKeysWithValues: members.map { ($0.id, $0) })
                 return .merge(
                     .run { [answerRepository] send in
                         do {
@@ -154,7 +157,7 @@ public struct QuestionDetailFeature {
                             let familyAnswers: [State.FamilyAnswer] = answers
                                 .filter { $0.userId != currentUserId }
                                 .map { answer in
-                                    let user = members.first(where: { $0.id == answer.userId })
+                                    let user = memberById[answer.userId]
                                         ?? User(id: answer.userId, email: "", name: "멤버",
                                                 profileImageURL: nil, role: .other, createdAt: Date())
                                     return State.FamilyAnswer(user: user, answer: answer)


### PR DESCRIPTION
## Jira
- [MG-68](https://ycompany.atlassian.net/browse/MG-68)

## Related (Q/A flow 성능 분석 시리즈)
- MG-66 P3 — MoodOption 정적 dict (#92)
- MG-67 P2 — performAnswerEdit 헬퍼화 (#94, 같은 파일)
- MG-69 P0 — TextField sending + scrollTo 정책 (예정)
- 권장 머지 순서: **#92 → #94 → #96 (MG-68) → MG-69**
- MG-67 머지 후 rebase 필요 (동일 파일 — onAppear 와 editCostPopup/.adHeartGranted 영역만 충돌 가능)

## Summary
- effect 진입 시점에 \`memberById = Dictionary(uniqueKeysWithValues: members.map { (\$0.id, \$0) })\` 1회 구축
- 답변 매칭은 \`memberById[answer.userId]\` O(1)
- nested O(F × A) → O(F + A)

## 효과
- 가족 5명·답변 5개: 25회 → 10회 (-60%)
- 가족 10명·답변 10개: 100회 → 20회 (5배 절감)

## Test plan
- [x] 빌드 성공
- [ ] 답변 화면 진입 — 가족 답변 카드별 이름/캐릭터 정확 매칭
- [ ] 탈퇴 멤버 답변 (dict miss) — 폴백 "멤버" 텍스트 표시

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)