### PR TITLE
fix(email-login): 잘못된 자격증명 → 사용자 친화 팝업 + APIError LocalizedError 채택 (MG-70)

### DIFF
--- a/MongleData/Sources/MongleData/DataSources/Remote/API/APIError.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/API/APIError.swift
@@ -72,6 +72,17 @@ public enum APIError: Error, Equatable {
     }
 }
 
+// MARK: - LocalizedError Conformance
+
+/// `localizedDescription` 프로퍼티만 정의해도 `Error` 가 NSError 로 브리지될 때
+/// Foundation 이 자동 메시지 ("작업을 완료할 수 없습니다. (...오류 N)") 를
+/// 만들어 사용자에게 노출하는 문제를 막는다.
+/// `LocalizedError.errorDescription` 을 구현해야 시스템 다이얼로그/`error.localizedDescription`
+/// 모두에서 우리 한국어 메시지가 나온다.
+extension APIError: LocalizedError {
+    public var errorDescription: String? { localizedDescription }
+}
+
 // MARK: - Server Error Response Body
 
 public struct ErrorResponse: Codable {

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/EmailAuth/EmailLoginFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/EmailAuth/EmailLoginFeature.swift
@@ -21,6 +21,10 @@ public struct EmailLoginFeature {
         public var passwordError: String?
         public var isSubmitting: Bool = false
         public var errorMessage: String?
+        /// 잘못된 이메일/비밀번호 입력 시 사용자에게 안내하는 팝업 상태.
+        /// 기존엔 alert 에 "MongleData.APIError 오류 7" 같은 raw 문자열이 노출되던 것을
+        /// 사용자 친화 팝업으로 분리.
+        public var showInvalidCredentialsAlert: Bool = false
 
         public var isEmailValid: Bool {
             guard email.contains("@"), email.contains(".") else { return false }
@@ -46,6 +50,7 @@ public struct EmailLoginFeature {
         case loginResponse(Result<SocialLoginResult, Error>)
 
         case dismissError
+        case dismissInvalidCredentialsAlert
         case backTapped
 
         case delegate(Delegate)
@@ -106,11 +111,25 @@ public struct EmailLoginFeature {
 
             case .loginResponse(.failure(let error)):
                 state.isSubmitting = false
-                state.errorMessage = (error as? AppError)?.userMessage ?? error.localizedDescription
+                // 모든 raw error → AppError 로 변환해 사용자 노출 메시지를 일관화.
+                // (이전엔 raw APIError 가 cast 실패해 localizedDescription 으로 넘어가
+                // "MongleData.APIError 오류 7" 같은 Foundation 자동 메시지 노출됐음)
+                let appError = error as? AppError ?? AppError.from(error)
+                // 이메일 로그인 컨텍스트의 401 = 잘못된 자격증명. 다른 화면의 "세션 만료"
+                // 의미와 분리해 명시적인 안내 팝업으로 처리.
+                if appError == .unauthorized {
+                    state.showInvalidCredentialsAlert = true
+                } else {
+                    state.errorMessage = appError.userMessage
+                }
                 return .none
 
             case .dismissError:
                 state.errorMessage = nil
+                return .none
+
+            case .dismissInvalidCredentialsAlert:
+                state.showInvalidCredentialsAlert = false
                 return .none
 
             case .backTapped:

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/EmailAuth/EmailLoginView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/EmailAuth/EmailLoginView.swift
@@ -91,6 +91,23 @@ struct EmailLoginView: View {
             },
             message: { Text(store.errorMessage ?? "") }
         )
+        .overlay {
+            if store.showInvalidCredentialsAlert {
+                MonglePopupView(
+                    icon: .init(
+                        systemName: "exclamationmark.lock.fill",
+                        foregroundColor: MongleColor.error,
+                        backgroundColor: MongleColor.bgErrorLight
+                    ),
+                    title: L10n.tr("email_login_invalid_title"),
+                    description: L10n.tr("email_login_invalid_desc"),
+                    primaryLabel: L10n.tr("common_confirm"),
+                    onPrimary: { store.send(.dismissInvalidCredentialsAlert) }
+                )
+                .transition(.opacity)
+                .animation(.easeInOut(duration: 0.2), value: store.showInvalidCredentialsAlert)
+            }
+        }
     }
 
     // MARK: - Helpers

--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -31,6 +31,8 @@
 "email_auth_login_title" = "Log in with email";
 "email_auth_login_subtitle" = "Enter your registered email and password.";
 "email_auth_login_submit" = "Log in";
+"email_login_invalid_title" = "Please check your login info";
+"email_login_invalid_desc" = "The email or password is incorrect.\nPlease check it again.";
 "email_auth_signup_title" = "Sign up with email";
 "email_auth_signup_subtitle" = "Enter your email and password.\nWe'll send a verification code to your email.";
 "email_auth_email_label" = "Email";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -31,6 +31,8 @@
 "email_auth_login_title" = "メールでログイン";
 "email_auth_login_subtitle" = "登録したメールアドレスとパスワードを入力してください。";
 "email_auth_login_submit" = "ログイン";
+"email_login_invalid_title" = "ログイン情報をご確認ください";
+"email_login_invalid_desc" = "メールアドレスまたはパスワードが正しくありません。\nもう一度ご確認ください。";
 "email_auth_signup_title" = "メールで登録";
 "email_auth_signup_subtitle" = "メールアドレスとパスワードを入力してください。\n入力いただいたメールに認証コードを送信します。";
 "email_auth_email_label" = "メールアドレス";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -31,6 +31,8 @@
 "email_auth_login_title" = "이메일로 로그인";
 "email_auth_login_subtitle" = "가입하신 이메일과 비밀번호를 입력해주세요.";
 "email_auth_login_submit" = "로그인";
+"email_login_invalid_title" = "로그인 정보를 확인해주세요";
+"email_login_invalid_desc" = "이메일 또는 비밀번호가 올바르지 않아요.\n다시 한 번 확인해주세요.";
 "email_auth_signup_title" = "이메일로 가입하기";
 "email_auth_signup_subtitle" = "이메일과 비밀번호를 입력해주세요.\n입력하신 이메일로 인증 코드를 보내드려요.";
 "email_auth_email_label" = "이메일";


### PR DESCRIPTION
## Jira
- [MG-70](https://ycompany.atlassian.net/browse/MG-70)

## Summary
- \`APIError: LocalizedError\` 채택 + \`errorDescription\` 구현 → \"MongleData.APIError 오류 N\" raw 노출 차단
- \`EmailLoginFeature\` 의 catch 분기를 \`AppError.from\` 변환 → \`.unauthorized\` 시 invalid credentials 팝업
- \`EmailLoginView\` 에 \`MonglePopupView\` overlay 추가 — \"이메일 또는 비밀번호를 확인해주세요\"
- ko/en/ja 번역 추가

## 효과
- 이메일 로그인 실패 메시지: \"작업을 완료할 수 없습니다.(MongleData.APIError 오류 7)\" → \"이메일 또는 비밀번호가 올바르지 않아요. 다시 한 번 확인해주세요.\"
- 다른 화면에서 APIError 누출 시에도 한국어 메시지로 노출

## 후속
- silent \`try?\` / \`?? []\` 사용으로 사용자 노출이 누락된 케이스 점검 → 별도 티켓 (MG-71)

## Test plan
- [x] 빌드 성공 (Debug, iPhone 16 Simulator)
- [ ] 잘못된 이메일/비밀번호 입력 시 MonglePopupView 노출
- [ ] 정상 자격증명 입력 시 팝업 미노출
- [ ] 네트워크 오류·서버 5xx 시 기존 alert 폴백
- [ ] 다국어 (en/ja) 노출 확인

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)