### PR TITLE
fix(error): 에러 노출 경로 AppError.from 변환 통일 — raw localizedDescription 7곳 (MG-71)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Consent/ConsentFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Consent/ConsentFeature.swift
@@ -144,7 +144,7 @@ public struct ConsentFeature {
 
             case .submitResponse(.failure(let error)):
                 state.isSubmitting = false
-                state.errorMessage = error.localizedDescription
+                state.errorMessage = AppError.from(error).userMessage
                 return .none
 
             case .dismissError:

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/EmailAuth/EmailSignupFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/EmailAuth/EmailSignupFeature.swift
@@ -213,7 +213,8 @@ public struct EmailSignupFeature {
 
             case .sendCodeResponse(.failure(let error)):
                 state.isSendingCode = false
-                state.errorMessage = (error as? AppError)?.userMessage ?? error.localizedDescription
+                // 모든 raw error → AppError 로 변환 (LocalizedError 미준수 raw 노출 방지)
+                state.errorMessage = (error as? AppError ?? AppError.from(error)).userMessage
                 return .none
 
             case .resendTimerTick:
@@ -273,7 +274,7 @@ public struct EmailSignupFeature {
 
             case .signupResponse(.failure(let error)):
                 state.isVerifying = false
-                let message = (error as? AppError)?.userMessage ?? error.localizedDescription
+                let message = (error as? AppError ?? AppError.from(error)).userMessage
                 state.codeError = message
                 return .none
 

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Login/LoginView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Login/LoginView.swift
@@ -250,7 +250,7 @@ private extension LoginView {
                   || nsError.code != ASAuthorizationError.canceled.rawValue
           else { return }
         }
-        store.send(.socialLoginFailed(error.localizedDescription))
+        store.send(.socialLoginFailed(AppError.from(error).userMessage))
       }
     }
   }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Search/SearchHistoryFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Search/SearchHistoryFeature.swift
@@ -86,7 +86,8 @@ public struct SearchHistoryFeature {
                         let history = try await questionRepository.getHistory(page: 1, limit: 100)
                         await send(.historyLoaded(history))
                     } catch {
-                        await send(.setError(error.localizedDescription))
+                        // raw error → AppError 변환으로 일관된 한국어 메시지
+                        await send(.setError(AppError.from(error).userMessage))
                     }
                 }
                 .cancellable(id: LoadID.load, cancelInFlight: true)

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Settings/SettingsFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Settings/SettingsFeature.swift
@@ -191,7 +191,8 @@ public struct SettingsFeature {
                         try await authRepository.deleteAccount()
                         await send(.deleteAccountSucceeded)
                     } catch {
-                        await send(.deleteAccountFailed(error.localizedDescription))
+                        // raw error 메시지 → AppError 변환 후 사용자 메시지로 노출
+                        await send(.deleteAccountFailed(AppError.from(error).userMessage))
                     }
                 }
 
@@ -240,7 +241,7 @@ public struct SettingsFeature {
                 return .none
 
             case .loadUserResponse(.failure(let error)):
-                state.errorMessage = error.localizedDescription
+                state.errorMessage = AppError.from(error).userMessage
                 return .none
 
             case .delegate:


### PR DESCRIPTION
## Jira
- [MG-71](https://ycompany.atlassian.net/browse/MG-71)

## Related
- MG-70 #100 — APIError LocalizedError + EmailLogin 팝업 (의존)
- MG-72 (예정) — 데이터 로드 실패 토스트
- MG-73 (예정) — Notification mutation rollback

## Summary
- EmailSignupFeature(2) / SettingsFeature(2) / SearchHistoryFeature(1) / ConsentFeature(1) / LoginView(1) — 7곳 모두 \`AppError.from(error).userMessage\` 통일
- raw \`error.localizedDescription\` 직접 사용 패턴 제거

## 효과
- raw 노출 경로 7곳 → 0
- URLError 도 fromURLError 경로로 offline/timeout/network 분류
- 화면 간 에러 메시지 일관성

## Test plan
- [x] 빌드 성공 (Debug, iPhone 16 Simulator)
- [ ] 이메일 회원가입 코드 발송 실패 (네트워크 차단)
- [ ] 계정 삭제 실패 (서버 에러 시뮬레이션)
- [ ] Search 히스토리 로드 실패
- [ ] Consent 약관 동의 실패
- [ ] Apple Sign In 실패 (취소가 아닌 실제 에러)

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)