### PR TITLE
fix(error): 데이터 로드 실패 사용자 안내 추가 — silent fallback 5곳 (MG-72)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationFeature.swift
@@ -179,10 +179,17 @@ public struct NotificationFeature {
             case .onAppear:
                 guard state.notifications.isEmpty else { return .none }
                 state.isLoading = true
+                state.errorMessage = nil
                 let scopeFamilyId = state.mode.scopeFamilyId
                 return .run { [notificationRepository] send in
-                    let items = (try? await notificationRepository.getNotifications(limit: 50, familyId: scopeFamilyId)) ?? []
-                    await send(.notificationsLoaded(items))
+                    // try? 로 silent fallback 하던 것을 do-catch 로 변경 — 실패 시
+                    // 사용자가 "알림 없음" 으로 오해하지 않도록 errorMessage 노출.
+                    do {
+                        let items = try await notificationRepository.getNotifications(limit: 50, familyId: scopeFamilyId)
+                        await send(.notificationsLoaded(items))
+                    } catch {
+                        await send(.setError(AppError.from(error).userMessage))
+                    }
                 }
 
             case .backTapped:
@@ -190,10 +197,15 @@ public struct NotificationFeature {
 
             case .refresh:
                 state.isLoading = true
+                state.errorMessage = nil
                 let scopeFamilyId = state.mode.scopeFamilyId
                 return .run { [notificationRepository] send in
-                    let items = (try? await notificationRepository.getNotifications(limit: 50, familyId: scopeFamilyId)) ?? []
-                    await send(.notificationsLoaded(items))
+                    do {
+                        let items = try await notificationRepository.getNotifications(limit: 50, familyId: scopeFamilyId)
+                        await send(.notificationsLoaded(items))
+                    } catch {
+                        await send(.setError(AppError.from(error).userMessage))
+                    }
                 }
 
             case .notificationTapped(let notification):

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationView.swift
@@ -32,6 +32,18 @@ public struct NotificationView: View {
         .onAppear {
             store.send(.onAppear)
         }
+        // 데이터 로드 실패 alert — 사용자가 "알림 없음" 으로 오해하지 않도록 노출.
+        .alert(
+            L10n.tr("error_unknown"),
+            isPresented: Binding(
+                get: { store.errorMessage != nil },
+                set: { if !$0 { store.send(.dismissError) } }
+            ),
+            actions: {
+                Button(L10n.tr("common_confirm")) { store.send(.dismissError) }
+            },
+            message: { Text(store.errorMessage ?? "") }
+        )
     }
 
     /// .filtered 모드에서 현재 그룹 기준으로 결과가 비어 있는 경우에도 emptyView 를 노출하기 위해

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/GroupManagementFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/GroupManagementFeature.swift
@@ -62,6 +62,7 @@ public struct GroupManagementFeature {
     public enum Action: Sendable, Equatable {
         case onAppear
         case groupDataLoaded(MongleGroup, [User])
+        case loadFailed(String)
         case inviteCodeCopyTapped
         case copiedToastDismissed
         case leaveGroupTapped
@@ -100,9 +101,18 @@ public struct GroupManagementFeature {
         Reduce { state, action in
             switch action {
             case .onAppear:
+                state.errorMessage = nil
+                // try? silent fallback → do-catch. 실패 시 사용자가 그룹 정보를
+                // 못 본 이유를 인지할 수 있도록 errorMessage 노출.
+                // getMyFamily() 는 Optional 반환 (가족 미가입 케이스) — nil 은 정상 흐름,
+                // throw 만 에러로 분류.
                 return .run { [familyRepository] send in
-                    if let result = try? await familyRepository.getMyFamily() {
-                        await send(.groupDataLoaded(result.0, result.1))
+                    do {
+                        if let result = try await familyRepository.getMyFamily() {
+                            await send(.groupDataLoaded(result.0, result.1))
+                        }
+                    } catch {
+                        await send(.loadFailed(AppError.from(error).userMessage))
                     }
                 }
 
@@ -120,6 +130,10 @@ public struct GroupManagementFeature {
                     let subtitle = isOwner ? "방장" : formatter.string(from: user.createdAt) + " 가입"
                     return State.GroupMember(id: user.id, name: user.name, subtitle: subtitle, moodId: user.moodId, isOwner: isOwner)
                 }
+                return .none
+
+            case .loadFailed(let message):
+                state.errorMessage = message
                 return .none
 
             case .inviteCodeCopyTapped:

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/HistoryCalendarFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/HistoryCalendarFeature.swift
@@ -11,6 +11,7 @@ public struct HistoryCalendarFeature {
         public var currentMonth: Date
         public var selectedDate: Date
         public var moodCalendar: [Date: String]
+        public var errorMessage: String?
 
         public init() {
             let today = Date()
@@ -20,15 +21,18 @@ public struct HistoryCalendarFeature {
             self.moodRecords = []
             self.isMoodLoading = false
             self.moodCalendar = [:]
+            self.errorMessage = nil
         }
     }
 
     public enum Action: Sendable, Equatable {
         case onAppear
         case moodLoaded([Domain.MoodRecord])
+        case loadFailed(String)
         case previousMonthTapped
         case nextMonthTapped
         case dateSelected(Date)
+        case dismissError
         case closeTapped
         case delegate(Delegate)
 
@@ -46,9 +50,16 @@ public struct HistoryCalendarFeature {
             switch action {
             case .onAppear:
                 state.isMoodLoading = true
+                state.errorMessage = nil
+                // try? silent fallback → do-catch 로 변경. 실패 시 사용자가 빈 차트로
+                // 오해하지 않도록 errorMessage 로 안내.
                 return .run { [moodRepository] send in
-                    let records = (try? await moodRepository.getRecentMoods(days: 31)) ?? []
-                    await send(.moodLoaded(records))
+                    do {
+                        let records = try await moodRepository.getRecentMoods(days: 31)
+                        await send(.moodLoaded(records))
+                    } catch {
+                        await send(.loadFailed(AppError.from(error).userMessage))
+                    }
                 }
 
             case .moodLoaded(let records):
@@ -59,6 +70,15 @@ public struct HistoryCalendarFeature {
                     cal[Calendar.current.startOfDay(for: record.date)] = record.mood
                 }
                 state.moodCalendar = cal
+                return .none
+
+            case .loadFailed(let message):
+                state.isMoodLoading = false
+                state.errorMessage = message
+                return .none
+
+            case .dismissError:
+                state.errorMessage = nil
                 return .none
 
             case .previousMonthTapped:

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/HistoryCalendarView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/HistoryCalendarView.swift
@@ -45,6 +45,17 @@ public struct HistoryCalendarView: View {
         }
         .navigationBarBackButtonHidden(true)
         .onAppear { store.send(.onAppear) }
+        .alert(
+            L10n.tr("error_unknown"),
+            isPresented: Binding(
+                get: { store.errorMessage != nil },
+                set: { if !$0 { store.send(.dismissError) } }
+            ),
+            actions: {
+                Button(L10n.tr("common_confirm")) { store.send(.dismissError) }
+            },
+            message: { Text(store.errorMessage ?? "") }
+        )
     }
 
     // MARK: - Month Navigation

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/MoodHistoryFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/MoodHistoryFeature.swift
@@ -9,6 +9,7 @@ public struct MoodHistoryFeature {
         public var moodRecords: [Domain.MoodRecord]
         public var isMoodLoading: Bool
         public var currentMonth: Date
+        public var errorMessage: String?
 
         public init() {
             let today = Date()
@@ -16,12 +17,15 @@ public struct MoodHistoryFeature {
             self.currentMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: today)) ?? today
             self.moodRecords = []
             self.isMoodLoading = false
+            self.errorMessage = nil
         }
     }
 
     public enum Action: Sendable, Equatable {
         case onAppear
         case moodLoaded([Domain.MoodRecord])
+        case loadFailed(String)
+        case dismissError
         case closeTapped
         case delegate(Delegate)
 
@@ -39,14 +43,29 @@ public struct MoodHistoryFeature {
             switch action {
             case .onAppear:
                 state.isMoodLoading = true
+                state.errorMessage = nil
+                // try? silent fallback → do-catch (사용자 노출)
                 return .run { [moodRepository] send in
-                    let records = (try? await moodRepository.getRecentMoods(days: 31)) ?? []
-                    await send(.moodLoaded(records))
+                    do {
+                        let records = try await moodRepository.getRecentMoods(days: 31)
+                        await send(.moodLoaded(records))
+                    } catch {
+                        await send(.loadFailed(AppError.from(error).userMessage))
+                    }
                 }
 
             case .moodLoaded(let records):
                 state.isMoodLoading = false
                 state.moodRecords = records
+                return .none
+
+            case .loadFailed(let message):
+                state.isMoodLoading = false
+                state.errorMessage = message
+                return .none
+
+            case .dismissError:
+                state.errorMessage = nil
                 return .none
 
             case .closeTapped:

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/MoodHistoryView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/MoodHistoryView.swift
@@ -35,6 +35,17 @@ public struct MoodHistoryView: View {
         }
         .navigationBarBackButtonHidden(true)
         .onAppear { store.send(.onAppear) }
+        .alert(
+            L10n.tr("error_unknown"),
+            isPresented: Binding(
+                get: { store.errorMessage != nil },
+                set: { if !$0 { store.send(.dismissError) } }
+            ),
+            actions: {
+                Button(L10n.tr("common_confirm")) { store.send(.dismissError) }
+            },
+            message: { Text(store.errorMessage ?? "") }
+        )
     }
 
     // MARK: - Summary (Pie Chart)


### PR DESCRIPTION
## Jira
- [MG-72](https://ycompany.atlassian.net/browse/MG-72)

## Related
- MG-70 #100 / MG-71 #102 (선행)
- MG-73 — Notification mutation rollback (예정)

## Summary
- (try? await ...) ?? [] silent 패턴 5곳 → do-catch + errorMessage
- 5개 feature: NotificationFeature, HistoryCalendarFeature, MoodHistoryFeature, GroupManagementFeature
- 4개 View 에 alert 추가 (GroupManagement 는 기존 popup 사용)
- HistoryCalendar/MoodHistory state 에 errorMessage 필드 + loadFailed 액션 + dismissError 액션 추가

## 효과
- silent 데이터 로드 실패 5곳 → 0
- 비행기모드 / 서버 오류 / 토큰 만료 케이스에서 사용자가 원인 인지

## Test plan
- [x] 빌드 성공 (Debug, iPhone 16 Simulator)
- [ ] 비행기모드 → 알림 화면 진입: alert 노출 확인
- [ ] 비행기모드 → 무드 14일 차트 진입: alert 확인
- [ ] 비행기모드 → 무드 히스토리 진입: alert 확인
- [ ] 비행기모드 → 그룹 관리 진입: 기존 popup 확인
- [ ] 가족 미가입 사용자 그룹 관리 진입: 정상 빈 화면 유지

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)