### PR TITLE
fix(notification): mutation 실패 사용자 안내 추가 (MG-73)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Notification/NotificationFeature.swift
@@ -197,13 +197,18 @@ public struct NotificationFeature {
                 }
 
             case .notificationTapped(let notification):
-                // 터치한 알림을 리스트에서 즉시 제거하고, 서버 삭제 완료 후 화면 이동
+                // 터치한 알림을 리스트에서 즉시 제거하고, 서버 삭제 완료 후 화면 이동.
+                // 서버 삭제 실패 시 errorMessage 로 안내 — 다음 refresh 에 알림이 다시
+                // 나타날 수 있으니 사용자가 인지하도록.
                 let deleteId = notification.id
-                // 새 배열 할당으로 @ObservableState 뷰 갱신 보장
                 state.notifications = state.notifications.filter { $0.id != notification.id }
                 let mode = state.mode
                 return .run { [notificationRepository] send in
-                    try? await notificationRepository.delete(id: deleteId)
+                    do {
+                        try await notificationRepository.delete(id: deleteId)
+                    } catch {
+                        await send(.setError(AppError.from(error).userMessage))
+                    }
                     await Self.syncAppIconBadge(notificationRepository)
                     switch mode {
                     case .grouped:
@@ -217,7 +222,9 @@ public struct NotificationFeature {
                 .cancellable(id: CancelID.badgeSync, cancelInFlight: true)
 
             case .markAsRead(let notification):
-                // Optimistic update
+                // Optimistic update — 서버 실패 시 errorMessage 만 노출하고 UI 는 유지.
+                // 다음 refresh 에 서버 상태로 자동 동기화. (rollback 으로 false 복원 시
+                // "방금 읽었던 알림이 다시 안읽음 표시" 라 오히려 혼란 큼.)
                 if let index = state.notifications.firstIndex(where: { $0.id == notification.id }) {
                     state.notifications[index] = MongleNotification(
                         id: notification.id,
@@ -230,8 +237,12 @@ public struct NotificationFeature {
                         createdAt: notification.createdAt
                     )
                 }
-                return .run { [notificationRepository] _ in
-                    _ = try? await notificationRepository.markAsRead(id: notification.id)
+                return .run { [notificationRepository] send in
+                    do {
+                        _ = try await notificationRepository.markAsRead(id: notification.id)
+                    } catch {
+                        await send(.setError(AppError.from(error).userMessage))
+                    }
                     await Self.syncAppIconBadge(notificationRepository)
                 }
                 .cancellable(id: CancelID.badgeSync, cancelInFlight: true)
@@ -253,16 +264,24 @@ public struct NotificationFeature {
                         createdAt: n.createdAt
                     )
                 }
-                return .run { [notificationRepository] _ in
-                    _ = try? await notificationRepository.markAllAsRead(familyId: scopeFamilyId)
+                return .run { [notificationRepository] send in
+                    do {
+                        _ = try await notificationRepository.markAllAsRead(familyId: scopeFamilyId)
+                    } catch {
+                        await send(.setError(AppError.from(error).userMessage))
+                    }
                     await Self.syncAppIconBadge(notificationRepository)
                 }
                 .cancellable(id: CancelID.badgeSync, cancelInFlight: true)
 
             case .deleteNotification(let notification):
                 state.notifications = state.notifications.filter { $0.id != notification.id }
-                return .run { [notificationRepository] _ in
-                    _ = try? await notificationRepository.delete(id: notification.id)
+                return .run { [notificationRepository] send in
+                    do {
+                        _ = try await notificationRepository.delete(id: notification.id)
+                    } catch {
+                        await send(.setError(AppError.from(error).userMessage))
+                    }
                     await Self.syncAppIconBadge(notificationRepository)
                 }
                 .cancellable(id: CancelID.badgeSync, cancelInFlight: true)
@@ -274,9 +293,14 @@ public struct NotificationFeature {
                 } else {
                     state.notifications = []
                 }
-                return .run { [notificationRepository] _ in
-                    _ = try? await notificationRepository.markAllAsRead(familyId: scopeFamilyId)
-                    _ = try? await notificationRepository.deleteAll(familyId: scopeFamilyId)
+                return .run { [notificationRepository] send in
+                    // markAllAsRead + deleteAll 두 단계. 어느 한쪽이라도 실패하면 안내.
+                    do {
+                        _ = try await notificationRepository.markAllAsRead(familyId: scopeFamilyId)
+                        _ = try await notificationRepository.deleteAll(familyId: scopeFamilyId)
+                    } catch {
+                        await send(.setError(AppError.from(error).userMessage))
+                    }
                     await Self.syncAppIconBadge(notificationRepository)
                 }
                 .cancellable(id: CancelID.badgeSync, cancelInFlight: true)


### PR DESCRIPTION
## Jira
- [MG-73](https://ycompany.atlassian.net/browse/MG-73)

## Related
- MG-70 #100 / MG-71 #102 / MG-72 #104 (선행)

## Summary
- delete/markAsRead/markAllAsRead/deleteNotification/deleteAll 의 try? silent 5곳 → do-catch + errorMessage
- 정책: Optimistic update 그대로 유지, rollback 은 하지 않음 (다음 refresh 에 서버 상태 자동 동기화)
- syncAppIconBadge / GroupSelect 의 read-mark delete 는 보조 동작이라 silent 유지

## 효과
- mutation silent 5곳 → 0
- 비행기모드 / 서버 오류 시 alert 노출
- AppError.from 변환으로 일관된 한국어 메시지

## Test plan
- [x] 빌드 성공 (Debug, iPhone 16 Simulator)
- [ ] 비행기모드 진입 후 단일 알림 삭제: alert 노출 + 다음 refresh 에 알림 복귀
- [ ] 비행기모드 → 모두 읽음: alert + 다음 refresh 에 미읽음 복귀
- [ ] 비행기모드 → 모두 삭제: alert + 다음 refresh 에 알림 복귀
- [ ] 비행기모드 → 알림 탭: alert + navigate 그대로 진행

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)