### PR TITLE
fix(home): 하트 안내 표기를 서버값(+1)과 동기화 (MG-74)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Support/HeartsSystemView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Support/HeartsSystemView.swift
@@ -69,7 +69,7 @@ public struct HeartsSystemView: View {
                     sectionTitle(L10n.tr("hearts_earn_title"), subtitle: L10n.tr("hearts_earn_subtitle"))
                     HStack(spacing: MongleSpacing.sm) {
                         miniHeartCard(title: L10n.tr("hearts_earn_login"), subtitle: L10n.tr("hearts_earn_login_sub"), value: "+1", tint: MongleColor.heartPastel)
-                        miniHeartCard(title: L10n.tr("hearts_earn_answer"), subtitle: L10n.tr("hearts_earn_answer_sub"), value: "+3", tint: MongleColor.heartPastelLight)
+                        miniHeartCard(title: L10n.tr("hearts_earn_answer"), subtitle: L10n.tr("hearts_earn_answer_sub"), value: "+1", tint: MongleColor.heartPastelLight)
                     }
                 }
 

--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -91,7 +91,7 @@
 "home_heart_replace" = "Replace question";
 "home_heart_write" = "Write my question";
 "home_heart_nudge" = "Nudge";
-"home_heart_earn_rate" = "Daily +1 · Answer +3";
+"home_heart_earn_rate" = "Daily +1 · Answer +1";
 "home_group_manage" = "Manage Groups";
 "home_answer_first_title" = "Please answer first";
 "home_answer_first_view" = "To see %@'s answer,\nyou need to answer today's question first";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -91,7 +91,7 @@
 "home_heart_replace" = "質問をもらい直す";
 "home_heart_write" = "自分だけの質問作成";
 "home_heart_nudge" = "催促する";
-"home_heart_earn_rate" = "毎朝 +1 · 回答完了 +3";
+"home_heart_earn_rate" = "毎朝 +1 · 回答完了 +1";
 "home_group_manage" = "グループ管理";
 "home_answer_first_title" = "まず回答を完了してください";
 "home_answer_first_view" = "%@の回答を見るには\nまず今日の質問に答えてください";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -91,7 +91,7 @@
 "home_heart_replace" = "질문 다시받기";
 "home_heart_write" = "나만의 질문 작성";
 "home_heart_nudge" = "재촉하기";
-"home_heart_earn_rate" = "매일 오전 +1 · 답변 완료 +3";
+"home_heart_earn_rate" = "매일 오전 +1 · 답변 완료 +1";
 "home_group_manage" = "그룹 관리";
 "home_answer_first_title" = "먼저 답변을 완료해 주세요";
 "home_answer_first_view" = "%@의 답변을 보려면\n먼저 오늘의 질문에 답변해야 해요";


### PR DESCRIPTION
## Jira
- [MG-74](https://ycompany.atlassian.net/browse/MG-74)

## Related
- 후속 서버 작업: [MG-75](https://ycompany.atlassian.net/browse/MG-75) — Daily heart 보너스 KST 타임존 + 트랜잭션 fix (이 PR 머지 후 작업 시작)

## Summary
- HeartsSystemView 답변 보상 카드 `value: "+3"` → `"+1"`
- `home_heart_earn_rate` 안내 ko/en/ja 3개 로케일 모두 "+3" → "+1"
- 실제 서버(`AnswerService.ts:86 hearts: { increment: 1 }`)와 표기 정합

## Test plan
- [ ] 라이트/다크 시뮬에서 Home 상단 하트 버튼 → 팝업 두 카드 모두 "+1"
- [ ] Home 본문 `home_heart_earn_rate` 안내 "+1" 표기
- [ ] en/ja 로케일 전환 후에도 "+1" 정합
- [ ] 실제 답변 제출 → hearts 카운트 +1만 증가 (서버 회귀)

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)