### PR TITLE
fix(home): hearts_use_skip_cost 표기를 서버값(-3)과 동기화 (MG-78)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "hearts_use_replace_cost" = "3 hearts";
 "hearts_use_skip" = "Force skip question";
 "hearts_use_skip_desc" = "Move to next question even with unanswered members";
-"hearts_use_skip_cost" = "5 hearts";
+"hearts_use_skip_cost" = "3 hearts";
 "hearts_save_title" = "Hearts are designed to be used wisely";
 "hearts_save_desc" = "Answering consistently helps you accumulate more hearts.";
 

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "hearts_use_replace_cost" = "ハート3個";
 "hearts_use_skip" = "強制スキップ";
 "hearts_use_skip_desc" = "未回答者がいても次の質問へ";
-"hearts_use_skip_cost" = "ハート5個";
+"hearts_use_skip_cost" = "ハート3個";
 "hearts_save_title" = "ハートは大切に使う仕組みです";
 "hearts_save_desc" = "回答を続けるほど安定的に貯めることができます。";
 

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "hearts_use_replace_cost" = "하트 3개";
 "hearts_use_skip" = "강제 질문 넘기기";
 "hearts_use_skip_desc" = "미답변 인원 있어도 다음 질문으로";
-"hearts_use_skip_cost" = "하트 5개";
+"hearts_use_skip_cost" = "하트 3개";
 "hearts_save_title" = "하트는 아껴 쓰는 구조예요";
 "hearts_save_desc" = "답변을 꾸준히 남길수록 더 안정적으로 모을 수 있어요.";
 


### PR DESCRIPTION
## Jira
- [MG-78](https://ycompany.atlassian.net/browse/MG-78)

## Summary
- ko/en/ja 3개 로케일 \`hearts_use_skip_cost\` "5" → "3"
- 서버 \`QuestionService.skipDailyQuestion\` -3 과 정합 (다른 안내 키들과도 통일)

## Test plan
- [ ] HeartsSystemView "강제 질문 넘기기" 카드 "하트 3개"
- [ ] 실제 스킵 시 -3 차감 (회귀 검증)

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)