### PR TITLE
fix(heart): 데일리 하트 팝업 트리거를 서버 플래그로만 정합 (MG-77)

### DIFF
--- a/Domain/Sources/Domain/Entities/User.swift
+++ b/Domain/Sources/Domain/Entities/User.swift
@@ -16,6 +16,11 @@ public struct User: Identifiable, Equatable, Sendable {
     public let hearts: Int
     public let moodId: String?
     public let createdAt: Date
+    /// 서버 /users/me?grantDailyHeart=true 응답에서 "이번 요청에 데일리 하트(+1)
+    /// 가 발생했는지" 플래그. RootFeature 가 이 값으로만 데일리 하트 팝업을
+    /// 띄운다 (UserDefaults 자체 카운터 제거, MG-77). opt-in 미포함 호출
+    /// (QuestionDetail/ProfileEdit hearts sync 등)에서는 항상 false.
+    public let heartGrantedToday: Bool
 
     public init(
         id: UUID,
@@ -25,7 +30,8 @@ public struct User: Identifiable, Equatable, Sendable {
         role: FamilyRole,
         hearts: Int = 0,
         moodId: String? = "loved",
-        createdAt: Date
+        createdAt: Date,
+        heartGrantedToday: Bool = false
     ) {
         self.id = id
         self.email = email
@@ -35,6 +41,7 @@ public struct User: Identifiable, Equatable, Sendable {
         self.hearts = hearts
         self.moodId = moodId
         self.createdAt = createdAt
+        self.heartGrantedToday = heartGrantedToday
     }
 }
 

--- a/Domain/Sources/Domain/Repositories/AuthRepositoryProtocol.swift
+++ b/Domain/Sources/Domain/Repositories/AuthRepositoryProtocol.swift
@@ -22,7 +22,13 @@ public protocol AuthRepositoryInterface: Sendable {
     /// - Kakao/Google: 클라이언트에서 unlink/disconnect 후 이 메서드 호출
     func deleteAccount() async throws
 
-    func getCurrentUser() async throws -> User?
+    /// 현재 로그인 사용자 조회.
+    /// - Parameter grantDailyHeart: true 인 호출만 서버에서 활성 그룹 데일리
+    ///   하트(+1) 지급을 동기 시도하고 응답 user.heartGrantedToday 에 결과를
+    ///   실어준다. RootFeature 의 onAppear / refreshHomeData 에서만 켜고,
+    ///   QuestionDetail/ProfileEdit 같은 hearts sync 호출은 default false 로
+    ///   호출해 거짓 grant 와 팝업 누락을 방지한다 (MG-77/MG-80).
+    func getCurrentUser(grantDailyHeart: Bool) async throws -> User?
 
     /// 약관/개인정보 동의 저장.
     /// - Parameters:

--- a/MongleData/Sources/MongleData/DTOs/UserDTO.swift
+++ b/MongleData/Sources/MongleData/DTOs/UserDTO.swift
@@ -18,4 +18,8 @@ struct UserDTO: Codable {
     let hearts: Int?
     let moodId: String?
     let createdAt: String
+    /// /users/me?grantDailyHeart=true 응답에서 활성 그룹 데일리 하트(+1)가
+    /// 이번 요청에 발생했는지 표시. opt-in 미포함 호출이거나 구버전 서버
+    /// 응답이면 nil 또는 false. (서버 변경: MG-80, 클라 사용처: MG-77)
+    let heartGrantedToday: Bool?
 }

--- a/MongleData/Sources/MongleData/DataSources/Remote/API/APIEndpoint.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/API/APIEndpoint.swift
@@ -85,7 +85,12 @@ enum AuthEndpoint: APIEndpoint {
     case logout
     /// 계정 완전 삭제 (서버에서 Apple token revoke 포함 처리)
     case deleteAccount
-    case getCurrentUser
+    /// 현재 로그인한 사용자 정보 조회.
+    /// grantDailyHeart=true 인 호출만 서버에서 그룹별 데일리 하트(+1) 지급을
+    /// 동기 시도하고 응답 heartGrantedToday 에 결과를 실어준다 (MG-77/MG-80).
+    /// onAppear / refreshHomeData 등 "세션 시작" 경로에서만 켜고, hearts sync
+    /// 같은 부수 호출은 default false 로 호출해 거짓 grant 를 방지한다.
+    case getCurrentUser(grantDailyHeart: Bool = false)
     case refreshToken(refreshToken: String)
     /// 약관/개인정보 동의 저장
     case submitConsent(termsVersion: String?, privacyVersion: String?)
@@ -95,6 +100,15 @@ enum AuthEndpoint: APIEndpoint {
     case emailSignup(email: String, password: String, code: String, name: String?, termsVersion: String, privacyVersion: String)
     /// 이메일/비밀번호 로그인 (기존 회원)
     case emailLogin(email: String, password: String)
+
+    var queryItems: [URLQueryItem]? {
+        switch self {
+        case .getCurrentUser(let grantDailyHeart):
+            return grantDailyHeart ? [URLQueryItem(name: "grantDailyHeart", value: "true")] : nil
+        default:
+            return nil
+        }
+    }
 
     var path: String {
         switch self {

--- a/MongleData/Sources/MongleData/DataSources/Remote/Services/AuthAPIService.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/Services/AuthAPIService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 protocol AuthAPIServiceProtocol {
     func logout() async throws
-    func getCurrentUser() async throws -> UserDTO?
+    func getCurrentUser(grantDailyHeart: Bool) async throws -> UserDTO?
 }
 
 final class AuthAPIService: AuthAPIServiceProtocol {
@@ -17,8 +17,8 @@ final class AuthAPIService: AuthAPIServiceProtocol {
         try await apiClient.request(endpoint)
     }
 
-    func getCurrentUser() async throws -> UserDTO? {
-        let endpoint = AuthEndpoint.getCurrentUser
+    func getCurrentUser(grantDailyHeart: Bool) async throws -> UserDTO? {
+        let endpoint = AuthEndpoint.getCurrentUser(grantDailyHeart: grantDailyHeart)
         do {
             let user: UserDTO = try await apiClient.request(endpoint)
             return user

--- a/MongleData/Sources/MongleData/Mappers/UserMapper.swift
+++ b/MongleData/Sources/MongleData/Mappers/UserMapper.swift
@@ -20,7 +20,8 @@ struct UserMapper {
             role: familyRole(from: dto.role),
             hearts: dto.hearts ?? 0,
             moodId: dto.moodId ?? "loved",
-            createdAt: parseISO8601(dto.createdAt)
+            createdAt: parseISO8601(dto.createdAt),
+            heartGrantedToday: dto.heartGrantedToday ?? false
         )
     }
 
@@ -46,7 +47,8 @@ struct UserMapper {
             familyId: nil,
             hearts: nil,
             moodId: domain.moodId,
-            createdAt: ISO8601DateFormatter().string(from: domain.createdAt)
+            createdAt: ISO8601DateFormatter().string(from: domain.createdAt),
+            heartGrantedToday: nil
         )
     }
 

--- a/MongleData/Sources/MongleData/Repositories/AuthRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/AuthRepository.swift
@@ -81,8 +81,8 @@ final class AuthRepository: AuthRepositoryInterface {
         try await apiClient.request(endpoint)
     }
 
-    func getCurrentUser() async throws -> User? {
-        let endpoint = AuthEndpoint.getCurrentUser
+    func getCurrentUser(grantDailyHeart: Bool) async throws -> User? {
+        let endpoint = AuthEndpoint.getCurrentUser(grantDailyHeart: grantDailyHeart)
         let userDTO: UserDTO = try await apiClient.request(endpoint)
         return UserMapper.toDomain(userDTO)
     }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -37,7 +37,11 @@ extension RootFeature {
                     state.appState = .loading
                     return .merge(
                         .run { send in
-                            let user = try? await authRepository.getCurrentUser()
+                            // grantDailyHeart: true — 콜드스타트 1차 /users/me 호출이 같은 KST 일자
+                            // 첫 호출이면 서버가 활성 그룹에 +1 지급. 이후 .refreshHomeData 의 2차
+                            // 호출은 같은 트리거를 보내도 서버가 idempotent 로 false 반환.
+                            // checkAuthResponse 에서 user.heartGrantedToday 로 팝업을 set-only 로 켠다.
+                            let user = try? await authRepository.getCurrentUser(grantDailyHeart: true)
                             await send(.checkAuthResponse(user))
                         },
                         .run { send in
@@ -66,8 +70,12 @@ extension RootFeature {
                     return .run { [authRepository, familyRepository, questionRepository, answerRepository, userRepository, notificationRepository] send in
                         do {
                             let data = try await Self.withTimeout(10) { () -> RootData in
-                            // 최신 사용자 정보 조회 (닉네임 변경 등 반영)
-                            let currentUser = try? await authRepository.getCurrentUser()
+                            // 최신 사용자 정보 조회 (닉네임 변경 등 반영) +
+                            // scenePhase active 등으로 본 경로만 진입한 케이스에선 여기서 데일리
+                            // 하트 grant 가 발동. user.heartGrantedToday 가 true 면 loadDataResponse
+                            // 에서 팝업을 set-only 로 켠다. 콜드스타트 경로(.onAppear → checkAuth)
+                            // 는 그쪽에서 이미 +1 처리되므로 본 호출은 idempotent 로 false 반환.
+                            let currentUser = try? await authRepository.getCurrentUser(grantDailyHeart: true)
                             let familyResult = try await familyRepository.getMyFamily()
                             let family = familyResult?.0
                             let familyMembers = familyResult?.1 ?? []
@@ -171,6 +179,13 @@ extension RootFeature {
                     if let user = user {
                         state.currentUser = user
                         state.appState = .loading
+                        // 콜드스타트(.onAppear → checkAuthResponse → refreshHomeData) 경로에서는
+                        // 이 1차 호출이 서버 grant 트리거이므로 여기서만 true 가 되고,
+                        // 2차 호출(refreshHomeData) 은 false 로 돌아옴. set-only 로 켜둬 두 단계
+                        // 사이에 사라지지 않게 한다.
+                        if user.heartGrantedToday {
+                            state.showHeartGrantedPopup = true
+                        }
                         return .send(.refreshHomeData)
                     } else {
                         state.appState = state.hasSeenOnboarding ? .unauthenticated : .onboarding
@@ -192,16 +207,14 @@ extension RootFeature {
                         try? await UNUserNotificationCenter.current().setBadgeCount(badgeCount)
                     }
 
-                    // 하루 첫 접속 하트 팝업 체크 (그룹별)
-                    if let familyId = data.family?.id, data.user != nil {
-                        let heartPopupKey = "mongle.lastHeartPopupDate.\(familyId)"
-                        let todayStart = Calendar.current.startOfDay(for: Date())
-                        let lastPopupDate = UserDefaults.standard.object(forKey: heartPopupKey) as? Date
-                        let isFirstAccessToday = lastPopupDate.map { Calendar.current.startOfDay(for: $0) < todayStart } ?? true
-                        if isFirstAccessToday {
-                            UserDefaults.standard.set(todayStart, forKey: heartPopupKey)
-                            state.showHeartGrantedPopup = true
-                        }
+                    // 데일리 하트 팝업 트리거 — 서버 응답 플래그만 신뢰 (MG-77).
+                    // scenePhase active 로 본 경로만 진입한 경우 여기 호출이 grant 트리거가 되며
+                    // user.heartGrantedToday 가 true 로 돌아온다. 콜드스타트 경로에서는 이미
+                    // checkAuthResponse 에서 set 된 상태이므로 여기 set-only 는 idempotent.
+                    // 이전 UserDefaults `mongle.lastHeartPopupDate.<familyId>` 자체 카운터는
+                    // 다중 단말 / 그룹 전환 / 서버 grant 실패 케이스에서 거짓 팝업을 유발해 폐기.
+                    if data.user?.heartGrantedToday == true {
+                        state.showHeartGrantedPopup = true
                     }
 
                     // mainTab이 아직 없는 경우 = 자동 로그인(첫 로드)

--- a/MongleFeatures/Tests/MongleFeaturesTests/RootFeatureTests.swift
+++ b/MongleFeatures/Tests/MongleFeaturesTests/RootFeatureTests.swift
@@ -94,4 +94,74 @@ final class RootFeatureTests: XCTestCase {
             $0.appState = .unauthenticated
         }
     }
+
+    // MARK: - MG-77: 데일리 하트 팝업은 서버 플래그로만 트리거
+
+    /// User 헬퍼 — 테스트에 필요한 최소 필드 + heartGrantedToday 플래그.
+    private func makeUser(heartGrantedToday: Bool) -> User {
+        User(
+            id: UUID(),
+            email: "test@mongle.app",
+            name: "테스터",
+            profileImageURL: nil,
+            role: .other,
+            hearts: 5,
+            moodId: "loved",
+            createdAt: Date(),
+            heartGrantedToday: heartGrantedToday
+        )
+    }
+
+    private func makeRootData(heartGrantedToday: Bool, family: MongleGroup?) -> RootFeature.RootData {
+        RootFeature.RootData(
+            user: makeUser(heartGrantedToday: heartGrantedToday),
+            question: nil,
+            family: family,
+            familyMembers: []
+        )
+    }
+
+    /// 서버가 heartGrantedToday=true 를 내리면 loadDataResponse 가 popup 을 켠다.
+    /// (scenePhase active 1차 진입 케이스 — refreshHomeData 의 /users/me 가 grant 트리거가 됨)
+    func testLoadDataSuccess_HeartGrantedToday_ShowsPopup() async {
+        let family = GroupFactory.make()
+        let initial = stateWithMainTab(family: family, appState: .authenticated)
+        let store = makeStore(initial: initial)
+        store.exhaustivity = .off
+
+        let data = makeRootData(heartGrantedToday: true, family: family)
+        await store.send(.loadDataResponse(.success(data))) {
+            $0.showHeartGrantedPopup = true
+        }
+    }
+
+    /// heartGrantedToday=false 면 popup 상태는 변하지 않는다 (set-only — 이전 값 보존).
+    /// 콜드스타트 2차 호출 시점이면 이미 checkAuthResponse 에서 set 됐을 수 있으므로
+    /// 여기서 reset 하지 않는 것이 핵심.
+    func testLoadDataSuccess_HeartNotGranted_PreservesExistingPopupState() async {
+        let family = GroupFactory.make()
+        var initial = stateWithMainTab(family: family, appState: .authenticated)
+        initial.showHeartGrantedPopup = true // 콜드스타트 1차에서 켜둔 상태 가정
+        let store = makeStore(initial: initial)
+        store.exhaustivity = .off
+
+        let data = makeRootData(heartGrantedToday: false, family: family)
+        await store.send(.loadDataResponse(.success(data)))
+        // showHeartGrantedPopup 는 true 로 보존돼야 함 (set-only)
+        XCTAssertTrue(store.state.showHeartGrantedPopup)
+    }
+
+    /// checkAuthResponse 에서 user.heartGrantedToday=true 면 popup 이 즉시 켜진다.
+    /// 콜드스타트 .onAppear → checkAuthResponse 1차 호출 시 grant 가 발동했을 때의 경로.
+    func testCheckAuthResponse_HeartGrantedToday_ShowsPopup() async {
+        let initial = RootFeature.State(appState: .loading)
+        let store = makeStore(initial: initial)
+        store.exhaustivity = .off
+
+        let user = makeUser(heartGrantedToday: true)
+        await store.send(.checkAuthResponse(user)) {
+            $0.currentUser = user
+            $0.showHeartGrantedPopup = true
+        }
+    }
 }


### PR DESCRIPTION
## Jira
- [MG-77](https://ycompany.atlassian.net/browse/MG-77)

## Related
- 선행 Server PR: [rrheon/Mongle-Server#53](https://github.com/rrheon/Mongle-Server/pull/53) (MG-80) — **prod 배포 완료 후** 본 PR 머지

## Summary
- `AuthRepositoryProtocol.getCurrentUser(grantDailyHeart: Bool)` 시그니처 확장 — onAppear / refreshHomeData 만 true 로 호출, QuestionDetail/ProfileEdit hearts sync 등 부수 호출은 default false 로 영향 없음
- `UserDTO.heartGrantedToday: Bool?` (서버 구버전 호환) + `Domain.User.heartGrantedToday: Bool` 필드 추가
- Root+Reducer 의 UserDefaults `mongle.lastHeartPopupDate.<familyId>` 카운터 블록 제거 → `data.user.heartGrantedToday` 로만 popup 트리거
- `checkAuthResponse` 와 `loadDataResponse(.success)` 양쪽 set-only — 콜드스타트(1차 grant → 2차 false) / scenePhase active(1회) 두 경로 모두 커버
- RootFeatureTests 3건 추가

## Test plan
- [x] Domain / MongleData SPM 빌드 통과 (MongleFeatures 는 사전 존재한 swift-perception/dependencies macro plugin 환경 이슈로 Xcode 빌드 별도 — 본 PR 변경과 무관)
- [ ] MG-80 prod 반영 확인 후 본 PR 머지 + TestFlight 빌드
- [ ] 자동 로그인 콜드 스타트 → 팝업 1회
- [ ] 노티 탭 진입 (콜드/워밍) → 팝업 동일
- [ ] scenePhase active 복귀 (오늘 첫) → 팝업 1회
- [ ] 같은 날 그룹 전환 → 새 그룹에서도 1회 팝업 (이전엔 +0 누락)
- [ ] QuestionDetail / ProfileEdit 진입 → grant 미발동, 팝업 미표시
- [ ] 단말 두 대 → 늦게 켠 단말은 팝업 미표시

## 호환성
구버전 iOS 는 `grantDailyHeart` 미전달 → 서버 default false → 본 PR 보급 전까지 데일리 하트 미수령. MG-80 prod 반영 직후 곧바로 빌드 올려 갭 최소화.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)