### PR TITLE
fix(auth): getCurrentUser() 무인자 오버로드 추가 (MG-77 hotfix)

### DIFF
--- a/Domain/Sources/Domain/Repositories/AuthRepositoryProtocol.swift
+++ b/Domain/Sources/Domain/Repositories/AuthRepositoryProtocol.swift
@@ -56,6 +56,16 @@ public protocol AuthRepositoryInterface: Sendable {
     func emailLogin(email: String, password: String) async throws -> SocialLoginResult
 }
 
+/// hearts sync 등 "세션 시작이 아닌" 부수 경로용 편의 메서드.
+/// Swift 프로토콜 요구사항은 호출 사이트에 default 값을 전파하지 않으므로,
+/// 명시적 opt-in 이 필요 없는 호출처가 매번 `grantDailyHeart: false` 를 적지
+/// 않도록 무인자 오버로드를 제공한다 (QuestionDetail/ProfileEdit 등).
+public extension AuthRepositoryInterface {
+    func getCurrentUser() async throws -> User? {
+        try await getCurrentUser(grantDailyHeart: false)
+    }
+}
+
 public enum AuthError: Error, Equatable, Sendable {
     case networkError
     case userNotFound


### PR DESCRIPTION
## Jira
- [MG-77](https://ycompany.atlassian.net/browse/MG-77)

## Context
[#112](https://github.com/rrheon/Mongle/pull/112) (MG-77) 머지본이 `AuthRepositoryInterface.getCurrentUser(grantDailyHeart:)` 단일 시그니처로 프로토콜을 변경하면서, 기존 `getCurrentUser()` 호출 사이트(`QuestionDetailFeature.swift:176`, `ProfileEditFeature.swift:84`)가 컴파일 에러를 일으킴.

Swift 프로토콜 요구사항은 default parameter 값을 호출 사이트에 자동 전파하지 않음 — 의도(부수 hearts sync 호출은 default false)를 명시적으로 표현하려면 protocol extension 의 무인자 오버로드가 필요.

## Summary
- `Domain/Sources/Domain/Repositories/AuthRepositoryProtocol.swift` 에 `extension AuthRepositoryInterface { func getCurrentUser() async throws -> User? }` 추가
- 내부에서 `grantDailyHeart=false` 로 forward → QuestionDetail / ProfileEdit 호출 사이트 변경 없이 컴파일 복구
- 의도된 부수 호출 시맨틱(grant 미발동) 유지

## Test plan
- [x] Domain SPM 빌드 통과
- [x] MongleData SPM 빌드 통과
- [ ] Xcode 워크스페이스 빌드 통과 (MongleFeatures 통합)
- [ ] QuestionDetail 진입 시 grant 미발동 확인 (회귀 없음)
- [ ] ProfileEdit hearts sync 시 grant 미발동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)