### PR TITLE
fix(settings): MY 탭에 약관/개인정보 처리방침 행 추가 (MG-109)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/ProfileEditView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/ProfileEditView.swift
@@ -6,11 +6,13 @@
 //
 
 import SwiftUI
+import SafariServices
 import ComposableArchitecture
 import Domain
 
 public struct ProfileEditView: View {
     @Bindable var store: StoreOf<ProfileEditFeature>
+    @State private var legalURL: URL?
 
     public init(store: StoreOf<ProfileEditFeature>) {
         self.store = store
@@ -34,6 +36,7 @@ public struct ProfileEditView: View {
 
                         moodSection
                         groupSection
+                        legalSection
 
                         Text(L10n.tr("settings_version", "1.0.0"))
                             .font(MongleFont.caption())
@@ -94,6 +97,10 @@ public struct ProfileEditView: View {
                 item: $store.scope(state: \.accountManagement, action: \.accountManagement)
             ) { accountStore in
                 AccountManagementView(store: accountStore)
+            }
+            .sheet(item: $legalURL) { url in
+                ProfileLegalSafariSheet(url: url)
+                    .ignoresSafeArea()
             }
         }
     }
@@ -195,6 +202,32 @@ public struct ProfileEditView: View {
         )
     }
 
+    // MARK: - 약관 및 정책
+
+    private var legalSection: some View {
+        settingsSection(
+            title: L10n.tr("settings_legal"),
+            rows: [
+                ProfileSettingsRow(
+                    icon: "doc.text.fill",
+                    iconColor: MongleColor.bgMintLight,
+                    iconBackground: MongleColor.primaryLight,
+                    title: L10n.tr("settings_terms"),
+                    subtitle: "",
+                    action: { legalURL = LegalLinks.termsURL }
+                ),
+                ProfileSettingsRow(
+                    icon: "lock.shield.fill",
+                    iconColor: MongleColor.bgMintLight,
+                    iconBackground: MongleColor.primaryLight,
+                    title: L10n.tr("settings_privacy"),
+                    subtitle: "",
+                    action: { legalURL = LegalLinks.privacyURL }
+                )
+            ]
+        )
+    }
+
     // MARK: - Settings Section Builder
 
   struct SettingsRowView: View {
@@ -275,6 +308,16 @@ public struct ProfileEditView: View {
 }
 
 // MARK: - Private Models
+
+private struct ProfileLegalSafariSheet: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
+}
 
 fileprivate struct ProfileSettingsRow: Identifiable {
     let id = UUID()

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/ProfileEditView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/ProfileEditView.swift
@@ -6,13 +6,12 @@
 //
 
 import SwiftUI
-import SafariServices
 import ComposableArchitecture
 import Domain
 
 public struct ProfileEditView: View {
     @Bindable var store: StoreOf<ProfileEditFeature>
-    @State private var legalURL: URL?
+    @Environment(\.openURL) private var openURL
 
     public init(store: StoreOf<ProfileEditFeature>) {
         self.store = store
@@ -97,10 +96,6 @@ public struct ProfileEditView: View {
                 item: $store.scope(state: \.accountManagement, action: \.accountManagement)
             ) { accountStore in
                 AccountManagementView(store: accountStore)
-            }
-            .sheet(item: $legalURL) { url in
-                ProfileLegalSafariSheet(url: url)
-                    .ignoresSafeArea()
             }
         }
     }
@@ -214,7 +209,7 @@ public struct ProfileEditView: View {
                     iconBackground: MongleColor.primaryLight,
                     title: L10n.tr("settings_terms"),
                     subtitle: "",
-                    action: { legalURL = LegalLinks.termsURL }
+                    action: { openURL(LegalLinks.termsURL) }
                 ),
                 ProfileSettingsRow(
                     icon: "lock.shield.fill",
@@ -222,7 +217,7 @@ public struct ProfileEditView: View {
                     iconBackground: MongleColor.primaryLight,
                     title: L10n.tr("settings_privacy"),
                     subtitle: "",
-                    action: { legalURL = LegalLinks.privacyURL }
+                    action: { openURL(LegalLinks.privacyURL) }
                 )
             ]
         )
@@ -308,16 +303,6 @@ public struct ProfileEditView: View {
 }
 
 // MARK: - Private Models
-
-private struct ProfileLegalSafariSheet: UIViewControllerRepresentable {
-    let url: URL
-
-    func makeUIViewController(context: Context) -> SFSafariViewController {
-        SFSafariViewController(url: url)
-    }
-
-    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
-}
 
 fileprivate struct ProfileSettingsRow: Identifiable {
     let id = UUID()


### PR DESCRIPTION
## Summary

- MY 탭(=`ProfileEditView`)에 **서비스 이용약관 / 개인정보 처리방침** 행 추가 — 안드로이드 `SettingsScreen.kt:371-394` 패리티
- 정책 페이지 진입 경로 부재(앱스토어 심사/GDPR/개인정보보호법 컴플라이언스 리스크) 해소
- `LegalLinks.termsURL`/`privacyURL` 재사용 — 기기 언어별 ko/en/ja Notion 페이지 자동 폴백

## 배경

`SettingsTabView.swift` 안에 `legalSection` 이 잘 구현되어 있었지만, `MainTabView.swift:92` 에서 MY 탭에 들어가는 화면은 `SettingsTabView` 가 아닌 **`ProfileEditView`** 였음. 즉 `SettingsTabView` 는 dead code 였고, 실제로 노출되는 `ProfileEditView` 에는 legalSection 이 누락되어 있었다.

## 변경 사항

`MongleFeatures/Sources/MongleFeatures/Presentation/Profile/ProfileEditView.swift`:
- `import SafariServices` 추가
- `@State private var legalURL: URL?` 추가
- `legalSection` 추가 (`groupSection` 다음, 버전 텍스트 직전)
  - 서비스 이용약관 — `doc.text.fill` 아이콘
  - 개인정보 처리방침 — `lock.shield.fill` 아이콘
- `.sheet(item: \$legalURL)` → `ProfileLegalSafariSheet`(SFSafariViewController)
- `URL: Identifiable` 확장은 `ConsentView.swift:198` 기존 정의 재사용 (충돌 없음)

## 비고

- GDPR/CCPA UMP \"개인정보 옵션\" 행은 `ProfileEditFeature` 에 `showPrivacyOptionsRow` state 가 없어 별도 작업으로 분리
- 기존 dead code `SettingsTabView` 정리는 별도 cleanup 이슈로 분리 권장

## Test plan

- [ ] MY 탭 진입 → \"약관 및 정책\" 섹션 노출
- [ ] \"서비스 이용약관\" 탭 → SFSafariViewController 로 termsURL 열림
- [ ] \"개인정보 처리방침\" 탭 → SFSafariViewController 로 privacyURL 열림
- [ ] 기기 언어 ko/en/ja 별 적합한 Notion 페이지 자동 분기 확인
- [ ] sheet 닫기 동작 정상

## Jira

- https://ycompany.atlassian.net/browse/MG-109

🤖 Generated with [Claude Code](https://claude.com/claude-code)