### PR TITLE
fix(push): APNs 환경 판단을 entitlement 런타임 검사로 변경 (MG-110)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/ApsEnvironmentDetector.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/ApsEnvironmentDetector.swift
@@ -7,10 +7,19 @@ import Foundation
 
 enum ApsEnvironmentDetector {
 
-    /// embedded.mobileprovision 의 Entitlements.aps-environment 를 읽어
-    /// "sandbox" 또는 "production" 을 반환한다. provisioning profile 이 없는
-    /// (App Store 정식 배포) 경우 production 으로 간주.
+    /// provisioning profile 의 aps-environment entitlement 으로 환경을 판단.
+    ///
+    /// - 시뮬레이터: embedded.mobileprovision 이 존재하지 않으나 토큰은 항상 sandbox
+    ///   로 발급되므로 무조건 "sandbox" 반환.
+    /// - 실기기 (Development profile): aps-environment = "development" → "sandbox"
+    /// - 실기기 (Distribution profile, TestFlight/App Store): aps-environment =
+    ///   "production" → "production"
+    /// - 정상 경로 실패 시 fallback 은 "production" — App Store 빌드(정식 배포)에
+    ///   embedded.mobileprovision 이 stripped 되는 케이스 보호.
     static func current() -> String {
+        #if targetEnvironment(simulator)
+        return "sandbox"
+        #else
         guard
             let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision"),
             let data = try? Data(contentsOf: url),
@@ -37,5 +46,6 @@ enum ApsEnvironmentDetector {
         }
 
         return apsEnv == "development" ? "sandbox" : "production"
+        #endif
     }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/ApsEnvironmentDetector.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/ApsEnvironmentDetector.swift
@@ -1,0 +1,41 @@
+//
+//  ApsEnvironmentDetector.swift
+//  MongleFeatures
+//
+
+import Foundation
+
+enum ApsEnvironmentDetector {
+
+    /// embedded.mobileprovision 의 Entitlements.aps-environment 를 읽어
+    /// "sandbox" 또는 "production" 을 반환한다. provisioning profile 이 없는
+    /// (App Store 정식 배포) 경우 production 으로 간주.
+    static func current() -> String {
+        guard
+            let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision"),
+            let data = try? Data(contentsOf: url),
+            let raw = String(data: data, encoding: .ascii)
+        else {
+            return "production"
+        }
+
+        guard
+            let plistStart = raw.range(of: "<?xml"),
+            let plistEnd = raw.range(of: "</plist>")
+        else {
+            return "production"
+        }
+
+        let plistString = String(raw[plistStart.lowerBound..<plistEnd.upperBound])
+        guard
+            let plistData = plistString.data(using: .utf8),
+            let plist = try? PropertyListSerialization.propertyList(from: plistData, format: nil) as? [String: Any],
+            let entitlements = plist["Entitlements"] as? [String: Any],
+            let apsEnv = entitlements["aps-environment"] as? String
+        else {
+            return "production"
+        }
+
+        return apsEnv == "development" ? "sandbox" : "production"
+    }
+}

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -775,14 +775,12 @@ extension RootFeature {
 
                 case .deviceTokenReceived(let data):
                     let token = data.map { String(format: "%02x", $0) }.joined()
-                    // aps-environment entitlement은 Xcode Run에서 항상 development로 고정되고,
-                    // Archive/Distribute 단계에서만 production으로 치환된다. 서버가 토큰별로
-                    // 올바른 APNs 호스트(sandbox / production)를 선택하도록 빌드 환경을 전송.
-                    #if DEBUG
-                    let environment = "sandbox"
-                    #else
-                    let environment = "production"
-                    #endif
+                    // aps-environment entitlement 을 런타임에 읽어 판단. embedded.mobileprovision
+                    // 의 Entitlements.aps-environment 가 "development" 면 sandbox, "production" 이면
+                    // production. Debug/Release scheme 과 무관하게 provisioning profile 기준이라
+                    // Xcode Run(Release scheme 포함) 은 sandbox, TestFlight/App Store 는 production
+                    // 으로 정확히 매핑된다.
+                    let environment = ApsEnvironmentDetector.current()
                     return .run { [userRepository] _ in
                         try? await userRepository.registerDeviceToken(token: token, environment: environment)
                     }


### PR DESCRIPTION
## Summary
- `#if DEBUG` 빌드 시점 분기 → `embedded.mobileprovision` 의 `aps-environment` entitlement 런타임 파싱으로 변경
- AdMob 때문에 Release 스킴이 강제되는 환경에서 Xcode Run 시 sandbox 토큰을 `'production'` 으로 잘못 등록하던 문제 해결
- 신규 `ApsEnvironmentDetector` 유틸 추가 — provisioning profile 진실값으로 판단

## Why
MG-22 가 도입한 `#if DEBUG` 분기는 빌드 configuration 기준이라 **Release 스킴 + Xcode Run** (Development profile) 케이스에서 깨짐:

| 빌드 | 토큰 환경 | `#if DEBUG` 결과 | 일치? |
|---|---|---|---|
| Debug + Xcode Run | sandbox | 'sandbox' | ✅ |
| **Release + Xcode Run** | **sandbox** | **'production'** | ❌ |
| Release + TestFlight/Store | production | 'production' | ✅ |

본 프로젝트는 AdMob 통합으로 Release 스킴이 일상 개발 흐름이라 이 케이스가 자주 노출되어 모든 푸시(스케줄/답변/재촉) 가 silent fail.

서버 인프라(`apnsEnvironment` 컬럼, 토큰별 호스트 선택) 는 그대로 활용. iOS 만 entitlement 런타임 검사로 보강.

## Test plan
- [ ] Release 스킴 + Xcode Run + 시뮬레이터 → DB 의 `apnsEnvironment` 가 `sandbox` 로 등록됨
- [ ] Release 스킴 + Xcode Run + 실기기 (Development profile) → 동일하게 `sandbox`
- [ ] TestFlight 빌드 → DB 가 `production` 으로 등록됨, 푸시 정상 수신 (회귀 無)
- [ ] 앱 재시작 시 environment 가 동일 값으로 유지 (sandbox ↔ production 토큰 churn 없음)
- [ ] 답변 / 재촉 / 11시 새 질문 / 19시 리마인더 모든 경로에서 푸시 수신

## Issue
[MG-110](https://ycompany.atlassian.net/browse/MG-110)

🤖 Generated with [Claude Code](https://claude.com/claude-code)