### PR TITLE
fix(push): 알림 탭 시 자동 markAsRead + 배지 동기화 (MG-111)

### DIFF
--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -70,6 +70,23 @@ class MongleAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let userInfo = response.notification.request.content.userInfo
+
+        // 푸시 페이로드의 notificationId 로 서버 알림을 즉시 읽음 처리 + OS 배지 동기화 (MG-111).
+        // 서버 측 AnswerService/NudgeService/QuestionService/reminderScheduler 가 페이로드에
+        // notificationId 를 실어 보내며, 클라가 알림을 탭한 시점에 in-app 알림함에 진입하지 않아도
+        // 미읽음 카운트가 누적되지 않도록 한다. Root+Reducer.loadDataResponse 의 setBadgeCount
+        // 동기화는 홈 진입 후에야 실행되므로 여기서 한 번 더 즉시 갱신해 사용자 체감 지연 방지.
+        if let notificationIdString = userInfo["notificationId"] as? String,
+           let notificationId = UUID(uuidString: notificationIdString) {
+            Task.detached {
+                let repository = makeNotificationRepository()
+                _ = try? await repository.markAsRead(id: notificationId)
+                if let unread = try? await repository.getUnreadCount() {
+                    try? await UNUserNotificationCenter.current().setBadgeCount(unread)
+                }
+            }
+        }
+
         if let type = userInfo["type"] as? String {
             switch type {
             // 모든 NotificationType (서버 schema 기준) 명시적 처리.


### PR DESCRIPTION
## Summary
- 트레이 알림 탭만으로 서버 unread 처리 + OS 배지 즉시 갱신
- iOS#2 (앱아이콘 알림 안 없어짐) / iOS#3 (알림 탭 시 읽음 처리) 동시 해결

## Changes
- `MongleApp.swift` `userNotificationCenter(_:didReceive:)`: `userInfo["notificationId"]` 추출 → `notificationRepository.markAsRead(id:)` + `getUnreadCount → setBadgeCount(unread)`
- 기존 `.openQuestion` 라우팅과 `completionHandler()` 호출은 그대로 유지

## 의존
- `Mongle-Server#56` (페이로드에 `notificationId` 포함) 머지 + 배포 후 효과 체감

## Side effects
- `Task.detached` 로 비동기 실행 → completionHandler 응답 지연 없음
- markAsRead 실패는 `try?` 로 silent — 알림함 진입 시 서버 기준 isRead 재정렬됨
- Root+Reducer.loadDataResponse 의 `setBadgeCount(unreadCountAllGroups)` 동기화는 홈 진입 후 발화하므로 didReceive 의 즉시 갱신과 idempotent

## 미해결
- iOS#1 (영이↔sxx 비대칭) 은 영이 측 토큰/`notifAnswer`/`apnsEnvironment` 데이터 진단 영역 — 별도 follow-up

## Test plan
- [x] xcodebuild Debug 빌드 성공 (iPhone 17 시뮬)
- [ ] TestFlight 빌드에서 답변/재촉 푸시 → 백그라운드 탭 → 서버 `Notification.isRead = true` 확인
- [ ] 동일 시나리오에서 OS 배지 -1 즉시 반영
- [ ] 포그라운드에서 푸시 수신 → didReceive 가 아닌 willPresent 흐름은 기존 그대로 (영향 없음 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)