### PR TITLE
fix(routing): 그룹 진입 시 home 강제 + 알림 type 별 라우팅 분기 (MG-116)

### DIFF
--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -89,17 +89,25 @@ class MongleAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
 
         if let type = userInfo["type"] as? String {
             switch type {
-            // 모든 NotificationType (서버 schema 기준) 명시적 처리.
-            // 누락 시 silent fail 방지 — 신규 type 추가 시 컴파일러가 경고하지 않더라도
-            // 이 switch 가 사용자 의도를 명확히 반영하도록 보강.
-            case "NEW_QUESTION", "MEMBER_ANSWERED", "ALL_ANSWERED",
-                 "ANSWER_REQUEST", "ANSWERER_NUDGE", "REMINDER", "BADGE_EARNED":
-                // 모두 홈/오늘 질문 화면으로 보내 사용자가 자연스럽게 답변/재촉으로 이어지게 함.
-                // 세부 라우팅 차별화는 follow-up.
+            // MG-116 — 본인이 즉시 답변해야 하는 알림은 답변 화면(.openQuestion), 그 외
+            // 그룹 컨텍스트 정보성 알림은 그룹 홈(.openHome) 으로 분기.
+            // - ANSWER_REQUEST: 다른 멤버가 본인을 재촉
+            // - REMINDER_UNANSWERED: 서버 reminderScheduler 가 본인 미답변 케이스로 발송
+            //   (DB Notification.type 은 'REMINDER' 그대로, push payload type 만 suffix 부여)
+            case "ANSWER_REQUEST", "REMINDER_UNANSWERED":
                 store?.send(.openQuestion)
+
+            // - NEW_QUESTION: 새 일일 질문 도착 (11시)
+            // - REMINDER_ANSWERED: 본인은 답변 완료. 그룹 미답변자 안내
+            // - REMINDER: legacy/구버전 페이로드 (suffix 미포함) — 안전 측 home
+            // - MEMBER_ANSWERED / ALL_ANSWERED / BADGE_EARNED / ANSWERER_NUDGE: 정보성
+            case "NEW_QUESTION", "REMINDER_ANSWERED", "REMINDER",
+                 "MEMBER_ANSWERED", "ALL_ANSWERED", "BADGE_EARNED", "ANSWERER_NUDGE":
+                store?.send(.openHome)
+
             default:
-                // 알 수 없는 type 은 안전한 기본 동작 — 홈 진입.
-                store?.send(.openQuestion)
+                // 알 수 없는 type — 안전한 기본 동작으로 그룹 홈 진입.
+                store?.send(.openHome)
             }
         }
         completionHandler()

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Action.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Action.swift
@@ -47,5 +47,8 @@ extension RootFeature {
         // MARK: Push Notification
         case deviceTokenReceived(Data)
         case openQuestion
+        // MG-116 — 알림 탭 시 그룹 home 으로 진입. ANSWER_REQUEST/REMINDER_UNANSWERED 가 아닌
+        // 모든 type 이 이 action 을 통해 mainTab.path 를 비우고 home 노출.
+        case openHome
     }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -477,6 +477,12 @@ extension RootFeature {
 
                 case .switchFamily(let family):
                     state.mainTab?.home.isLoading = true
+                    // MG-116 — 그룹 전환은 무조건 해당 그룹의 home 으로 진입한다.
+                    // 이전 그룹의 sub-screen (QuestionDetail, History 상세, ProfileEdit 모달 등)
+                    // 이 활성 상태에서 그룹 전환하면 새 그룹 데이터 위로 이전 그룹 화면이
+                    // 그대로 남는 혼란 방지.
+                    state.mainTab?.modal = nil
+                    state.mainTab?.path.removeAll()
                     return .run { [familyRepository] send in
                         do {
                             _ = try await familyRepository.selectFamily(familyId: family.id)
@@ -807,6 +813,16 @@ extension RootFeature {
                     } else {
                         // 아직 데이터 로딩 중 → 로딩 완료 후 이동
                         state.pendingOpenQuestion = true
+                    }
+                    return .none
+
+                case .openHome:
+                    // MG-116 — 알림 탭 등 외부 트리거로 그룹 home 으로 진입. mainTab.path 와 modal 을
+                    // 비워 어떤 sub-screen 에 있었든 home 으로 복귀하게 한다. 미인증 상태 / 데이터 미로드
+                    // 케이스는 자연스럽게 부팅 흐름이 home 까지 데려가므로 별도 pending 플래그 불필요.
+                    if state.appState == .authenticated {
+                        state.mainTab?.modal = nil
+                        state.mainTab?.path.removeAll()
                     }
                     return .none
                 }


### PR DESCRIPTION
재오픈 PR. 원본 #117 은 stacked base 가 머지로 삭제되며 자동 close 됨.

## Summary
- 알림 탭 / 그룹 전환 시 무조건 해당 그룹의 home 진입
- ANSWER_REQUEST / REMINDER_UNANSWERED 만 답변 화면

## Changes
- Root+Action: .openHome 추가
- Root+Reducer .openHome / .switchFamily: modal=nil + path.removeAll()
- MongleApp.didReceive: type 별 분기

서버 (Mongle-Server MG-116) 머지 후 효과 체감.

🤖 Generated with [Claude Code](https://claude.com/claude-code)