### PR TITLE
fix(push): MongleFeatures SPM 에 DEBUG 매크로 정의 (MG-114)

### DIFF
--- a/MongleFeatures/Package.swift
+++ b/MongleFeatures/Package.swift
@@ -64,6 +64,14 @@ let package = Package(
                 .process("Assets.xcassets"),
                 .process("Fonts"),
                 .process("Resources")
+            ],
+            // SPM 패키지는 메인 앱 타겟의 SWIFT_ACTIVE_COMPILATION_CONDITIONS 를 상속하지
+            // 않아서, 명시 정의가 없으면 #if DEBUG 가 항상 false 로 컴파일된다. 그 결과
+            // Root+Reducer 의 deviceTokenReceived 가 DEBUG 빌드에서도 environment="production"
+            // 으로 등록 → BadDeviceToken → 서버 자동 invalidate → 푸시 미수신 무한 루프.
+            // .when(configuration: .debug) 가드로 Debug 에서만 매크로 정의. (MG-114)
+            swiftSettings: [
+                .define("DEBUG", .when(configuration: .debug))
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## Summary
- SPM 패키지의 `MongleFeatures` 타겟에 `.define(\"DEBUG\", .when(configuration: .debug))` swiftSettings 추가
- DEBUG 빌드에서 APNs `environment` 가 `sandbox` 로 정상 등록되도록 수정 — 무한 BadDeviceToken/invalidate 사이클 해소

## 배경

DEBUG 빌드 install 후 디바이스에서 푸시가 한 번도 도달하지 않는 증상 추적 결과 다음 사이클이 진행 중이었음:

1. DEBUG 빌드 install → iOS 가 sandbox 토큰 발급
2. 클라가 `environment=\"production\"` 으로 잘못 등록 (이번 PR 의 root cause)
3. 서버가 `api.push.apple.com` (production) 으로 발송
4. Apple `400 BadDeviceToken` 거부
5. 서버 `invalidateApnsToken` 자동 정리 → `apnsToken=null`, `apnsEnvironment=null`
6. 이후 발송은 token 가드로 skip
7. 재로그인 시 1) 부터 무한 반복

## 원인

`Root+Reducer.swift:782-794` 의 `#if DEBUG / #else` 분기:

```swift
#if DEBUG
let environment = \"sandbox\"
#else
let environment = \"production\"
#endif
```

이 코드가 `MongleFeatures` SPM 패키지 안에 위치. `Mongle.xcodeproj` 메인 앱 타겟엔 `SWIFT_ACTIVE_COMPILATION_CONDITIONS = \"DEBUG\"` 가 Debug 컨피그에 정의되어 있지만, **SPM 패키지는 이를 상속받지 않음**. 패키지 매니페스트에 명시 정의가 없어 `#if DEBUG` 는 항상 false 로 컴파일.

## 변경

`MongleFeatures/Package.swift` 의 `MongleFeatures` 타겟에 swiftSettings 추가:

```swift
swiftSettings: [
    .define(\"DEBUG\", .when(configuration: .debug))
]
```

`.when(configuration: .debug)` 가드로 **Debug 컨피그에서만** 매크로 정의. Release 빌드(Archive/TestFlight/AppStore) 에서는 매크로 미정의 → 정상적으로 production 분기로 컴파일.

## DB 검증

- `kakao:4799026828` (ㅋㅋ 사용자) 재설치 직후 `apnsToken` 저장됨 + `apnsEnvironment=production` → production 호스트 발송 시 BadDeviceToken → invalidate 패턴 재현 확인
- 같은 토큰으로 sandbox 호스트 직접 발송 시 `200 OK` 받고 디바이스에 알림 도달 — 토큰 자체는 정상이고 호스트 라우팅만 잘못된 것이 확정됨

## 빌드 검증
- `xcodebuild -project Mongle.xcodeproj -scheme Mongle -destination 'generic/platform=iOS Simulator' -configuration Debug build` → **BUILD SUCCEEDED**

## 호환성
- Release 빌드 영향 없음 (`.when(configuration: .debug)` 가드)
- 메인 앱 타겟의 `#if DEBUG` 는 그대로 작동 (영향 없음)
- 다른 SPM 의존 (`Domain`, `MongleData`) 는 따로 `#if DEBUG` 사용 안 함 → 무관. 추후 사용 시 동일 패턴 적용 권장

## Test plan
- [ ] 머지 후 Xcode pull → Debug 빌드 → 디바이스에 install (앱 삭제 후 재설치 권장 — 이전 invalidate 흔적 정리)
- [ ] 권한 허용 후 DB `users.apns_environment` 가 **`sandbox`** 으로 저장되는지 확인 (이전엔 production)
- [ ] 안드로이드 → iOS 재촉 / 답변 / 새질문 발송 → iOS 트레이/잠금화면/배너 노출 확인
- [ ] BadDeviceToken 으로 인한 자동 invalidate 더 이상 발생 안 함 (`apnsToken` 유지)
- [ ] 회귀 — Release 빌드 (Archive) 시 `apns_environment=production` 정상 저장

## 관련
- 이번 사이클 마지막 root cause fix. 앞선 MG-111 (서버 페이로드) / MG-112 (Android FCM 엔드포인트) / MG-113 (iOS willPresent) 와 함께 안드로이드/iOS 양 플랫폼 푸시 시스템 정상화

🤖 Generated with [Claude Code](https://claude.com/claude-code)