### PR TITLE
fix(push): APNs environment 결정을 호스트 앱으로 이관 (MG-114 follow-up)

### DIFF
--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -30,7 +30,17 @@ class MongleAppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
 
     /// APNs 토큰 등록 성공
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        store?.send(.deviceTokenReceived(deviceToken))
+        // aps-environment entitlement 은 Xcode Run 빌드에서 development 로 고정되고
+        // Archive/Distribute 시 production 으로 치환된다. 서버가 올바른 APNs 호스트
+        // (sandbox / production) 를 선택하도록 빌드 환경을 전송.
+        // 호스트 앱 타겟의 #if DEBUG 는 SWIFT_ACTIVE_COMPILATION_CONDITIONS 로 보장되어
+        // SPM 캐시 영향 없이 신뢰 가능. SPM 안에서 결정하던 옛 방식의 회귀 차단. (MG-114)
+        #if DEBUG
+        let environment = "sandbox"
+        #else
+        let environment = "production"
+        #endif
+        store?.send(.deviceTokenReceived(deviceToken, environment: environment))
     }
 
     /// APNs 토큰 등록 실패 — 디버깅 단서 + 서버 측 stale 토큰 유지 방지를 위한 로그.

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Action.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Action.swift
@@ -45,7 +45,10 @@ extension RootFeature {
         case dismissQuestionDetail
 
         // MARK: Push Notification
-        case deviceTokenReceived(Data)
+        // environment 는 호스트 앱(Mongle 타겟)의 #if DEBUG 분기로 결정되어 전달.
+        // SPM 패키지 안에서는 swiftSettings.define + Xcode SPM 캐시 조합이 신뢰 불가
+        // 했음을 실측 확인 — sandbox/production 결정을 호스트 앱으로 이관. (MG-114)
+        case deviceTokenReceived(Data, environment: String)
         case openQuestion
         // MG-116 — 알림 탭 시 그룹 home 으로 진입. ANSWER_REQUEST/REMINDER_UNANSWERED 가 아닌
         // 모든 type 이 이 action 을 통해 mainTab.path 를 비우고 home 노출.

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -779,16 +779,12 @@ extension RootFeature {
 
                 // MARK: Push Notification
 
-                case .deviceTokenReceived(let data):
+                case .deviceTokenReceived(let data, let environment):
                     let token = data.map { String(format: "%02x", $0) }.joined()
-                    // aps-environment entitlement은 Xcode Run에서 항상 development로 고정되고,
-                    // Archive/Distribute 단계에서만 production으로 치환된다. 서버가 토큰별로
-                    // 올바른 APNs 호스트(sandbox / production)를 선택하도록 빌드 환경을 전송.
-                    #if DEBUG
-                    let environment = "sandbox"
-                    #else
-                    let environment = "production"
-                    #endif
+                    // environment 는 MongleApp.swift (호스트 앱 타겟) 의 #if DEBUG 분기로
+                    // 결정되어 전달된 값. SPM 패키지의 swiftSettings.define 만으로는
+                    // Xcode SPM 캐시 영향으로 항상 production 으로 컴파일되는 케이스 발생.
+                    // 결정 로직을 호스트 앱으로 이관. (MG-114)
                     return .run { [userRepository] _ in
                         try? await userRepository.registerDeviceToken(token: token, environment: environment)
                     }


### PR DESCRIPTION
## Summary
- 이전 PR #120 의 SPM `swiftSettings.define("DEBUG", .when(.debug))` 만으로는 사용자 디바이스에서 environment 가 여전히 `production` 으로 저장됨이 실측 확인됨
- environment 결정 로직을 SPM 패키지 안의 Reducer → 호스트 앱 (`Mongle/MongleApp.swift`) 으로 이관
- 호스트 앱 타겟의 `SWIFT_ACTIVE_COMPILATION_CONDITIONS` 는 SPM 캐시 영향 없이 신뢰 가능

## 배경

MG-114 PR #120 머지 후 두 차례 빌드 install 검증 모두 `apns_environment=production` 으로 저장 (`d001704f...`, `4576e59f...` 토큰들). 단계 모두 거쳤음에도 결과 동일:
- File → Packages → Reset Package Caches
- Product → Clean Build Folder (⇧⌘K)
- `~/Library/Developer/Xcode/DerivedData/Mongle-*` 삭제
- 디바이스 앱 삭제 후 재설치
- main HEAD 9245162 (PR #120 머지 커밋) 에서 빌드

Xcode 의 SPM 빌드 캐시 / Module Cache 가 일부 환경에서 매우 끈질겨 `Package.swift` 의 새 `swiftSettings` 가 신뢰 가능하게 적용되지 않는 케이스 존재. 표준적인 캐시 무효화 절차로도 풀리지 않음.

## 변경

### `MongleFeatures/Sources/.../Root+Action.swift`
```diff
- case deviceTokenReceived(Data)
+ case deviceTokenReceived(Data, environment: String)
```

### `MongleFeatures/Sources/.../Root+Reducer.swift`
```diff
- case .deviceTokenReceived(let data):
+ case .deviceTokenReceived(let data, let environment):
      let token = data.map { String(format: "%02x", $0) }.joined()
-     #if DEBUG
-     let environment = "sandbox"
-     #else
-     let environment = "production"
-     #endif
      return .run { [userRepository] _ in
          try? await userRepository.registerDeviceToken(token: token, environment: environment)
      }
```

### `Mongle/MongleApp.swift`
```diff
  func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-     store?.send(.deviceTokenReceived(deviceToken))
+     #if DEBUG
+     let environment = "sandbox"
+     #else
+     let environment = "production"
+     #endif
+     store?.send(.deviceTokenReceived(deviceToken, environment: environment))
  }
```

## 호환성

- 호출처는 `MongleApp.swift` 1곳뿐 — 회귀 위험 없음
- Release 빌드 동작 동일 (`#if DEBUG` 가 false → environment="production")
- 이전 PR #120 의 `Package.swift` swiftSettings 는 그대로 유지 — 손해 없고 보강 효과
- SPM 캐시 / 빌드 컨피그 영향 모두에서 자유로워짐

## 빌드 검증
- `xcodebuild -project Mongle.xcodeproj -scheme Mongle -destination 'generic/platform=iOS Simulator' -configuration Debug build` → **BUILD SUCCEEDED**

## Test plan
- [ ] 머지 후 Xcode pull → Debug 빌드 → 디바이스 install
- [ ] 권한 허용 → DB `users.apns_environment` 가 **`sandbox`** 으로 저장되는지 확인
- [ ] 안드로이드 → iOS 재촉/답변 발송 시 BadDeviceToken/invalidate 패턴 더 이상 발생하지 않음
- [ ] iOS 트레이/잠금화면 알림 정상 노출 (MG-113 willPresent fix 와 함께 종단 검증)
- [ ] Release 빌드 (Archive) 시 environment="production" 정상 (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)