### PR TITLE
fix(ios-home): 본인 캐릭터 이름에 (나) 마커 추가 (MG-120)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Design/Components.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Design/Components.swift
@@ -1220,7 +1220,11 @@ public struct MongleView: View {
         Button(action: handleTap) {
             VStack(spacing: 4) {
                 statusBadge
-                MongleMonggle(color: color, name: name)
+                // MG-120 — 본인 캐릭터는 이름 옆에 "(나)" suffix 를 붙여 status badge 색상에
+                // 더해 즉시 식별 가능하게 한다. MongleMonggle 자체는 다른 곳에서도 재사용되므로
+                // 호출 site 인 MongleView 에서만 처리.
+                let displayName = isCurrentUser ? "\(name) \(L10n.tr("home_member_me_suffix"))" : name
+                MongleMonggle(color: color, name: displayName)
             }
         }
         .buttonStyle(.plain)

--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -83,6 +83,8 @@
 
 /* Home */
 "home_default_group" = "Mongle";
+/* Suffix appended to own character name on group home (MG-120) */
+"home_member_me_suffix" = "(me)";
 "home_today_question" = "Today's Question";
 "home_question_placeholder" = "A new question arrives at 11 AM";
 "home_answer_complete" = "Answered";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -83,6 +83,8 @@
 
 /* Home */
 "home_default_group" = "モングル";
+/* 自分のキャラクター名の横に付くマーカー (MG-120) */
+"home_member_me_suffix" = "(私)";
 "home_today_question" = "今日の質問";
 "home_question_placeholder" = "午前11時に新しい質問が届きます";
 "home_answer_complete" = "回答済み";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -83,6 +83,8 @@
 
 /* Home */
 "home_default_group" = "몽글";
+/* 본인 캐릭터 이름 옆에 붙는 마커 (MG-120) */
+"home_member_me_suffix" = "(나)";
 "home_today_question" = "오늘의 질문";
 "home_question_placeholder" = "오전 11시에 새로운 질문이 도착해요";
 "home_answer_complete" = "답변 완료";


### PR DESCRIPTION
## Summary
- 그룹 홈 씬에서 본인 캐릭터의 이름 라벨 옆에 "(나)" suffix 추가 — status badge 색상만으로는 답변 완료 상태에서 본인/타인 구분이 약했던 문제 보완
- 한국어 "(나)" / 영어 "(me)" / 일본어 "(私)" 3 로케일 string 추가
- 게스트 모드(`currentUserName == nil`)는 `isCurrentUser=false` 분기로 마커 미노출 — 회귀 없음
- `MongleMonggle` 자체는 다른 곳(레벨 뱃지/프리뷰)에서도 재사용되므로 직접 수정 금지 — `MongleView` 호출 site 에서만 처리

## 변경 내역
- `Components.swift:1219-1230` — `MongleView.body` 의 `MongleMonggle` 호출 시 `isCurrentUser` 분기로 displayName 결정
- `ko.lproj`/`en.lproj`/`ja.lproj` Localizable.strings — `home_member_me_suffix` 키 신규

## Android
별도 티켓 (MG-119) 으로 동일 변경 적용. PR #64.

## Test plan
- [ ] 본인 캐릭터 이름이 `이름 (나)` 형태로 표시
- [ ] 다른 멤버 이름은 그대로 (회귀 없음)
- [ ] 게스트 모드 진입 시 어떤 캐릭터에도 (나) 마커 없음
- [ ] 영어/일본어 로케일에서도 적절한 suffix 표시
- [ ] 레벨 뱃지/프리뷰 등 `MongleMonggle` 다른 사용처 회귀 없음
- [x] `xcodebuild build -scheme Mongle -destination 'generic/platform=iOS Simulator'` BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)