### PR TITLE
fix(ios-group): 그룹 생성/참여 — TextField 자동 포커스 이동 (MG-124)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectView+CreateGroup.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectView+CreateGroup.swift
@@ -64,6 +64,9 @@ extension GroupSelectView {
             .font(MongleFont.body2())
             .foregroundColor(MongleColor.textPrimary)
             .focused($createGroupFocus, equals: .groupName)
+            // MG-124 — "다음" 키보드 버튼으로 닉네임 필드 자동 포커스 이동 (AOS 패리티)
+            .submitLabel(.next)
+            .onSubmit { createGroupFocus = .nickname }
         }
         .padding(MongleSpacing.md)
         .background(Color.white)
@@ -107,6 +110,9 @@ extension GroupSelectView {
             .font(MongleFont.body2())
             .foregroundColor(MongleColor.textPrimary)
             .focused($createGroupFocus, equals: .nickname)
+            // MG-124 — 마지막 필드는 "완료" 로 키보드 dismiss. .createNextTapped 자동 트리거는 하지 않음 (실수 입력 방지).
+            .submitLabel(.done)
+            .onSubmit { createGroupFocus = nil }
         }
         .padding(MongleSpacing.md)
         .background(Color.white)

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectView+JoinWithCode.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectView+JoinWithCode.swift
@@ -41,6 +41,9 @@ extension GroupSelectView {
             .textCase(.uppercase)
             .autocorrectionDisabled()
             .focused($joinGroupFocus, equals: .joinCode)
+            // MG-124 — "다음" 키보드 버튼으로 닉네임 필드 자동 포커스 이동 (AOS 패리티)
+            .submitLabel(.next)
+            .onSubmit { joinGroupFocus = .nickname }
         }
         .padding(MongleSpacing.md)
         .background(Color.white)
@@ -84,6 +87,9 @@ extension GroupSelectView {
             .font(MongleFont.body2())
             .foregroundColor(MongleColor.textPrimary)
             .focused($joinGroupFocus, equals: .nickname)
+            // MG-124 — 마지막 필드는 "완료" 로 키보드 dismiss. .joinTapped 자동 트리거는 하지 않음 (실수 입력 방지).
+            .submitLabel(.done)
+            .onSubmit { joinGroupFocus = nil }
         }
         .padding(MongleSpacing.md)
         .background(Color.white)


### PR DESCRIPTION
## Summary

- 그룹 참여(`JoinWithCode`) / 그룹 생성(`CreateGroup`) 화면 입력 폼에 키보드 "다음" 버튼이 보이지 않고 다음 필드로 자동 포커스 이동도 안 되던 문제 수정
- AOS `GroupSelectScreen` 의 `ImeAction.Next` + `focusManager.moveFocus(FocusDirection.Down)` 패리티
- 기존 `@FocusState` / `.focused()` / `.onChange(focusField)` 인프라는 그대로 — `submitLabel` + `onSubmit` 만 추가

## 변경 위치

| 파일 | 필드 | 추가 |
| --- | --- | --- |
| `GroupSelectView+JoinWithCode.swift:34-43` | 초대코드 | `.submitLabel(.next)` + `.onSubmit { joinGroupFocus = .nickname }` |
| `GroupSelectView+JoinWithCode.swift:79-86` | 닉네임 | `.submitLabel(.done)` + `.onSubmit { joinGroupFocus = nil }` |
| `GroupSelectView+CreateGroup.swift:59-66` | 공간이름 | `.submitLabel(.next)` + `.onSubmit { createGroupFocus = .nickname }` |
| `GroupSelectView+CreateGroup.swift:102-109` | 닉네임 | `.submitLabel(.done)` + `.onSubmit { createGroupFocus = nil }` |

마지막 닉네임 필드는 `.done` 으로 키보드만 닫음. `.joinTapped` / `.createNextTapped` 자동 트리거는 하지 않음 — 실수 입력 방지.

## Jira

[MG-124](https://ycompany.atlassian.net/browse/MG-124)

## Test plan

- [ ] 그룹 참여: 초대코드 입력 → 키보드 "다음" → 닉네임 포커스 자동 이동
- [ ] 그룹 참여: 닉네임 입력 → 키보드 "완료" → 키보드 dismiss (자동 가입 시도 X)
- [ ] 그룹 생성: 공간이름 입력 → 키보드 "다음" → 닉네임 포커스 자동 이동
- [ ] 그룹 생성: 닉네임 입력 → 키보드 "완료" → 키보드 dismiss
- [ ] 키보드 우하단 라벨이 "Return" → "다음" / "완료" 로 변경되어 노출
- [ ] 외부 액션(예: 에러 발생 시 자동 포커스 복귀) 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)