### PR TITLE
fix(ios-group): 새 공간 만들기 — 복사 버튼 텍스트 Black (MG-125)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectView+GroupCreated.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectView+GroupCreated.swift
@@ -54,9 +54,10 @@ extension GroupSelectView {
             codeCopied = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) { codeCopied = false }
           } label: {
+            // MG-125 — primary 그린 텍스트 + primaryLight 그린 배경 contrast 부족. 검정으로 가독성 확보.
             Label(codeCopied ? L10n.tr("common_copied") : L10n.tr("common_copy"), systemImage: codeCopied ? "checkmark" : "doc.on.doc")
               .font(MongleFont.captionBold())
-              .foregroundColor(codeCopied ? MongleColor.success : MongleColor.primary)
+              .foregroundColor(.black)
               .padding(.horizontal, MongleSpacing.sm)
               .padding(.vertical, MongleSpacing.xxs)
               .background(codeCopied ? MongleColor.success.opacity(0.12) : MongleColor.primaryLight)
@@ -90,9 +91,10 @@ extension GroupSelectView {
             linkCopied = true
             DispatchQueue.main.asyncAfter(deadline: .now() + 2) { linkCopied = false }
           } label: {
+            // MG-125 — primary 그린 텍스트 + primaryLight 그린 배경 contrast 부족. 검정으로 가독성 확보.
             Label(linkCopied ? L10n.tr("common_copied") : L10n.tr("common_copy"), systemImage: linkCopied ? "checkmark" : "doc.on.doc")
               .font(MongleFont.captionBold())
-              .foregroundColor(linkCopied ? MongleColor.success : MongleColor.primary)
+              .foregroundColor(.black)
               .padding(.horizontal, MongleSpacing.sm)
               .padding(.vertical, MongleSpacing.xxs)
               .background(linkCopied ? MongleColor.success.opacity(0.12) : MongleColor.primaryLight)


### PR DESCRIPTION
## Summary

- `groupCreatedView` 의 초대코드/초대링크 옆 "복사" 버튼 Label 이 `MongleColor.primary` 그린 텍스트 + `MongleColor.primaryLight` 연한 그린 배경으로 그려져 contrast 부족
- 두 Label 의 `.foregroundColor` 를 `Color.black` 으로 변경 (상태 무관)
- 배경색은 시각 피드백 위해 그대로 유지 — "복사됨" 트랜지션은 배경 색상 변화로 인지 가능
- AOS MG-123 패리티

## 변경 위치

`GroupSelectView+GroupCreated.swift`

| 라인 | Before | After |
| --- | --- | --- |
| 59 | `.foregroundColor(codeCopied ? MongleColor.success : MongleColor.primary)` | `.foregroundColor(.black)` |
| 95 | `.foregroundColor(linkCopied ? MongleColor.success : MongleColor.primary)` | `.foregroundColor(.black)` |

## Jira

[MG-125](https://ycompany.atlassian.net/browse/MG-125)

## Test plan

- [ ] 새 공간 생성 직후 화면의 "복사" 버튼 텍스트/아이콘이 검정으로 또렷하게 표시
- [ ] "복사" 탭 → "복사됨" 상태로 전환 시에도 텍스트는 검정 유지, 배경만 success 톤으로 변화
- [ ] 초대코드 row + 초대링크 row 두 버튼 모두 동일 적용
- [ ] 다크 모드 진입 시 가독성 회귀 없음
- [ ] 다른 화면의 `MongleColor.primary` 사용처 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)