### PR TITLE
fix(push): OS 배지를 서버 unread-count API 로 단일화 (MG-126)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -148,8 +148,10 @@ extension RootFeature {
                             let hasUnreadNotifications = notifications.contains {
                                 !$0.isRead && $0.familyId == currentFamilyId
                             }
-                            // OS 앱 아이콘 배지는 사용자 단위(그룹 개념 없음)이므로 전체 그룹 합산.
-                            let unreadCountAllGroups = notifications.filter { !$0.isRead }.count
+                            // OS 앱 아이콘 배지는 서버 unread-count API 결과만 사용 (MG-126).
+                            // 이전: notifications.filter { !$0.isRead }.count — list 응답(limit:50,
+                            // 그룹 필터 없음) 합산이라 cap/필터 누락으로 과다 계상 발생.
+                            let unreadCountAllGroups = (try? await notificationRepository.getUnreadCount()) ?? 0
 
                             return RootData(
                                 user: currentUser,


### PR DESCRIPTION
## Summary
- iOS OS 앱 아이콘 배지가 실제보다 과다 계상되던 문제 수정 (재현: 실제 미수신 알림보다 훨씬 큰 숫자가 표시됨)
- `Root+Reducer.swift` 홈 새로고침 경로의 OS 배지 갱신 출처를 list 응답 합산 → 서버 `/notifications/unread-count` API 결과로 단일화
- `NotificationFeature` 의 mark-read/delete 경로와 출처 일치 → 두 경로 race/불일치 제거

## Why
기존 `notifications.filter { !\$0.isRead }.count` 합산 로직은 세 가지 결함이 있음:
- `getNotifications(limit: 50)` cap — 실제 unread > 50 일 때 부정확
- 호출 시 `familyId` 필터 없음 — 그룹 단위 정의와 무관하게 합산되며 list 컨텍스트와 다름
- 표시용 페이지네이션 응답을 카운트 source 로 사용 — 정의 자체의 모호성

`NotificationFeature.swift:412, 417` 는 이미 서버 unread-count API 를 쓰고 있어, 두 경로가 분리되어 있었음. 이 PR 로 둘을 통일.

## 변경 파일
- `MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift` (+4 / -2)

## Test plan
- [ ] 앱 콜드 스타트 직후 OS 배지 = 서버 `/notifications/unread-count` 응답값
- [ ] 알림 1개 수신 → 배지 +1
- [ ] 알림함에서 모두 읽음 → 배지 0
- [ ] 다른 가족 그룹으로 전환 → 배지 그대로 (사용자 단위 카운트 유지)
- [ ] scenePhase active 복귀 / foreground push 수신 시 동일한 숫자
- [ ] Home 빨간 점(현재 그룹 미읽음) 표시는 기존과 동일하게 동작

## 후속 (별도 티켓 예정)
배포 후에도 배지가 비정상적으로 크게 유지되면 서버 `getUnreadCount` 정의 자체를 손봐야 함:
- (a) TTL 기반 만료 (`createdAt > now() - 14d`)
- (b) `REMINDER` 같은 자동 발생 타입 unread 제외
- (c) 알림함 진입 시 자동 읽음

Jira: [MG-126](https://ycompany.atlassian.net/browse/MG-126)

🤖 Generated with [Claude Code](https://claude.com/claude-code)