### PR TITLE
feat(ios-ad): 서버 /config 기반 광고 토글 (MG-132)

### DIFF
--- a/Domain/Sources/Domain/Entities/AppConfig.swift
+++ b/Domain/Sources/Domain/Entities/AppConfig.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// 서버 /config 응답을 표현하는 도메인 엔티티 (MG-132).
+public struct AppConfig: Sendable, Equatable {
+    public let isAdEnabled: Bool
+
+    public init(isAdEnabled: Bool) {
+        self.isAdEnabled = isAdEnabled
+    }
+}

--- a/Domain/Sources/Domain/Repositories/ConfigRepositoryProtocol.swift
+++ b/Domain/Sources/Domain/Repositories/ConfigRepositoryProtocol.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol ConfigRepositoryProtocol: Sendable {
+    /// 서버 /config 호출. 성공 시 AppConfig 반환, 실패 시 throw.
+    /// 호출자가 결과를 캐시 (UserDefaults 등) 에 저장하는 책임을 진다.
+    func fetch() async throws -> AppConfig
+}

--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -150,6 +150,19 @@ struct MongleApp: App {
 
         MongleFont.registerFonts()
         SocialSDK.initialize()
+        // 서버 /config (MG-132) — 광고 토글 캐시 갱신. 동의 흐름보다 먼저 시작해
+        // 다음 부팅부터 ConsentManager / AdBannerSection 분기에 최신값이 반영된다.
+        // 실패는 silent — AdConfigStore 의 기본값(true) 또는 직전 캐시 유지.
+        Task.detached(priority: .utility) {
+            do {
+                let config = try await makeConfigRepository().fetch()
+                AdConfigStore.set(config.isAdEnabled)
+            } catch {
+                #if DEBUG
+                print("[Config] /config fetch 실패 — 기존 캐시 유지: \(error.localizedDescription)")
+                #endif
+            }
+        }
         // GDPR/CCPA 동의 흐름(UMP). KR·JP 는 건너뛰고 즉시 AdMob 초기화,
         // 그 외 지역은 동의 폼 표시 후 AdMob 초기화한다.
         ConsentManager.shared.startConsentFlowIfNeeded()

--- a/MongleData/Sources/MongleData/DataSources/Remote/API/APIEndpoint.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/API/APIEndpoint.swift
@@ -641,6 +641,17 @@ enum MoodEndpoint: APIEndpoint {
     }
 }
 
+// MARK: - Config Endpoints
+
+enum ConfigEndpoint: APIEndpoint {
+    /// GET /config — 클라이언트 설정 (광고 토글 등). 인증 불필요. (MG-132)
+    case get
+
+    var path: String { "/config" }
+    var method: HTTPMethod { .get }
+    var queryItems: [URLQueryItem]? { nil }
+}
+
 // MARK: - Notification Endpoints
 
 enum NotificationEndpoint: APIEndpoint {

--- a/MongleData/Sources/MongleData/MongleData.swift
+++ b/MongleData/Sources/MongleData/MongleData.swift
@@ -42,6 +42,10 @@ public func makeNotificationRepository() -> any NotificationRepositoryProtocol {
     NotificationRepository()
 }
 
+public func makeConfigRepository() -> any ConfigRepositoryProtocol {
+    ConfigRepository()
+}
+
 // MARK: - 첫 실행 / 로그아웃 시 정리 헬퍼
 
 /// iOS 는 앱 uninstall 후 재설치 시 Keychain 항목을 자동으로 지우지 않는다.

--- a/MongleData/Sources/MongleData/Repositories/ConfigRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/ConfigRepository.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Domain
+
+final class ConfigRepository: ConfigRepositoryProtocol {
+    private let apiClient: APIClientProtocol
+
+    init(apiClient: APIClientProtocol = APIClient.shared) {
+        self.apiClient = apiClient
+    }
+
+    func fetch() async throws -> AppConfig {
+        struct Response: Decodable {
+            let isAdEnabled: Bool
+        }
+        let response: Response = try await apiClient.request(ConfigEndpoint.get)
+        return AppConfig(isAdEnabled: response.isAdEnabled)
+    }
+}

--- a/MongleFeatures/Sources/MongleFeatures/AdConfigStore.swift
+++ b/MongleFeatures/Sources/MongleFeatures/AdConfigStore.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// 서버 /config 응답을 캐시하는 source-of-truth (MG-132).
+///
+/// MongleApp.init() 가 부팅 시 ConfigRepository.fetch() → [set] 으로 갱신한다.
+/// AdBannerView 와 ConsentManager 는 [isAdEnabled] 를 읽어 광고 렌더링 / AdMob 초기화
+/// 여부를 결정한다.
+///
+/// 기본값은 true (광고 표시) — 첫 부팅 / 네트워크 실패 시 운영 사고 없이 기존 동작 유지.
+/// 운영자가 서버 환경변수 ADS_ENABLED=false 로 OFF 한 뒤 다음 부팅부터 반영된다.
+public enum AdConfigStore {
+    private static let key = "mongle.adConfig.isAdEnabled"
+
+    public static var isAdEnabled: Bool {
+        // object(forKey:) 가 nil 이면 미설정 → 기본값 true. bool(forKey:) 단독 사용 시
+        // 미설정 / false 구분이 안 돼서 첫 부팅이 false 로 잘못 해석되는 회귀 방지.
+        guard UserDefaults.standard.object(forKey: key) != nil else { return true }
+        return UserDefaults.standard.bool(forKey: key)
+    }
+
+    public static func set(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: key)
+    }
+}

--- a/MongleFeatures/Sources/MongleFeatures/AppDependencies.swift
+++ b/MongleFeatures/Sources/MongleFeatures/AppDependencies.swift
@@ -126,5 +126,18 @@ extension DependencyValues {
     }
 }
 
+// MARK: - ConfigRepository
+
+private enum ConfigRepositoryKey: DependencyKey {
+    static let liveValue: any ConfigRepositoryProtocol = makeConfigRepository()
+}
+
+extension DependencyValues {
+    public var configRepository: any ConfigRepositoryProtocol {
+        get { self[ConfigRepositoryKey.self] }
+        set { self[ConfigRepositoryKey.self] = newValue }
+    }
+}
+
 // NOTE: ErrorHandler는 ErrorHandlerDependency.swift에서 DependencyKey를 직접 구현합니다.
 // @Dependency(\.errorHandler) 로 사용하세요.

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Common/AdBannerView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Common/AdBannerView.swift
@@ -27,12 +27,16 @@ public struct AdBannerSection: View {
     public init() {}
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            AdBannerView()
-                .frame(height: 50)
-                .frame(maxWidth: .infinity)
-                .background(Color(hex: "#F5F5F5"))
-                .clipShape(RoundedRectangle(cornerRadius: MongleRadius.large))
+        // 서버 /config (MG-132) — 비활성 시 layout 공간도 차지하지 않도록 EmptyView 반환.
+        // 호출자 (Settings/Home/History 등) 의 분기 코드는 불필요.
+        if AdConfigStore.isAdEnabled {
+            VStack(alignment: .leading, spacing: 8) {
+                AdBannerView()
+                    .frame(height: 50)
+                    .frame(maxWidth: .infinity)
+                    .background(Color(hex: "#F5F5F5"))
+                    .clipShape(RoundedRectangle(cornerRadius: MongleRadius.large))
+            }
         }
     }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Common/ConsentManager.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Common/ConsentManager.swift
@@ -60,6 +60,14 @@ public final class ConsentManager {
     /// - 그 외 지역이면 최상위 ViewController 가 준비된 뒤 UMP 동의 폼을 노출하고,
     ///   동의 결과와 무관하게(거부 시 비개인화 광고) AdMob 을 초기화한다.
     public func startConsentFlowIfNeeded() {
+        // 서버 /config (MG-132) — 광고 OFF 일 때 UMP / ATT / AdMob 초기화 모두 건너뛴다.
+        // SDK 가 로드되지 않으므로 메모리·네트워크·광고 ID 풋프린트도 함께 절약.
+        guard AdConfigStore.isAdEnabled else {
+            #if DEBUG
+            print("[ConsentManager] 광고 비활성 (서버 설정) — UMP / ATT / AdMob 초기화 건너뜀")
+            #endif
+            return
+        }
         // DEBUG 빌드에서 디버그 모드가 활성화된 경우에는 KR/JP 판정도 UMP 가 수행하도록 하여
         // 테스트 지역을 강제로 시뮬레이션할 수 있게 한다.
         #if !DEBUG


### PR DESCRIPTION
## Summary
- `GET /config` (서버 MG-131) → `AppConfig { isAdEnabled }`
- 부팅 시 `Task.detached` 로 `ConfigRepository.fetch()` 비차단 호출 → `AdConfigStore` (UserDefaults) 캐시 갱신
- `ConsentManager.startConsentFlowIfNeeded()`: `isAdEnabled=false` 면 UMP / ATT / AdMob 초기화 모두 건너뜀 → SDK 미로드로 메모리·네트워크·광고 ID 풋프린트 절약
- `AdBannerSection`: `isAdEnabled=false` 면 EmptyView 반환 (layout 공간 0) — 호출자 분기 코드 불필요

## 추가 파일
- `Domain/Entities/AppConfig.swift` + `Repositories/ConfigRepositoryProtocol.swift`
- `MongleData/Repositories/ConfigRepository.swift` + `ConfigEndpoint`
- `MongleFeatures/AdConfigStore.swift` — UserDefaults 기반. `object(forKey:)` nil 체크 후 `bool(forKey:)` 사용 → 첫 부팅 false 오해석 방지
- `AppDependencies` 에 `configRepository` TCA Dependency 등록

## 안전 기본값
- `AdConfigStore.isAdEnabled` 기본값 = true → 첫 부팅 / 네트워크 실패 시 기존 동작 유지
- 운영자가 서버 `ADS_ENABLED=false` 로 OFF 한 뒤 다음 부팅부터 반영

## Test plan
- [x] xcodebuild iOS Simulator Debug → BUILD SUCCEEDED
- [ ] 서버 `ADS_ENABLED=true` (기본) → 광고 노출 + AdMob init 정상 + UMP 흐름 정상
- [ ] 서버 `ADS_ENABLED=false` 로 변경 → 다음 부팅 시 AdBannerSection 미노출 + Xcode console 에 \"광고 비활성\" 로그
- [ ] /config 호출 실패 (네트워크 OFF) → 직전 캐시 또는 기본값(true) 으로 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)