### PR TITLE
fix(ios-input): 한글 IME 조합 중 글자가 일시 누락/투명으로 보이는 회생 차단 (MG-134)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectFeature.swift
@@ -204,12 +204,16 @@ public struct GroupSelectFeature {
                 return .none
 
             case .groupNameChanged(let name):
-                state.groupName = String(name.prefix(10))
+                // (MG-134) 10자 이하는 원본 그대로 — String(prefix:) 가 새 인스턴스를 생성해
+                // 한글 IME 조합 중 markedTextRange 를 invalidate 시키는 회생 차단. (joinCode 는
+                // 영문/숫자 전용이라 IME 영향 없으므로 기존 패턴 유지.)
+                state.groupName = name.count <= 10 ? name : String(name.prefix(10))
                 state.groupNameError = false
                 return .none
 
             case .nicknameChanged(let name):
-                state.nickname = String(name.prefix(10))
+                // (MG-134) 같은 IME 회생 차단.
+                state.nickname = name.count <= 10 ? name : String(name.prefix(10))
                 state.nicknameError = false
                 return .none
 

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Question/QuestionDetailFeature.swift
@@ -185,7 +185,10 @@ public struct QuestionDetailFeature {
 
             case .answerTextChanged(let text):
                 guard !state.isSubmitting else { return .none }
-                state.answerText = String(text.prefix(200))
+                // (MG-134) 200자 이하는 원본 그대로 — String(prefix:) 가 새 인스턴스를 생성해
+                // SwiftUI binding setter 가 호출되면 한글 IME 조합 중 markedTextRange 가
+                // invalidate 되어 입력 중 글자가 누락/투명으로 보이는 회생을 차단.
+                state.answerText = text.count <= 200 ? text : String(text.prefix(200))
                 state.appError = nil
                 return .none
 


### PR DESCRIPTION
## 증상
답변 작성 시 \`오늘 기쁨\` 입력 → 화면에 \`오늘  쁨\` 처럼 일부 글자가 사라지거나 투명하게 보이는 케이스. 한글 입력 시에만 발생, iOS 전용 (Android 는 input connection 모델이 달라 동일 회생 없음).

## 원인
TCA reducer 의 textChanged 액션이 매 입력마다 \`String(text.prefix(N))\` 으로 새 String 인스턴스를 만들어 state 에 다시 넣음. SwiftUI binding setter 가 호출되는 시점이 한글 IME 의 자모 조합(composing) 중과 겹치면 UITextField 내부의 \`markedTextRange\` (조합 중인 자모 범위) 가 invalidate 되어 조합 중인 글자가 일시적으로 누락/투명으로 렌더링됨. iOS 16+ \`TextField(axis: .vertical)\` 에서 잘 노출됨.

## 수정 (length <= limit 이면 원본 그대로 — 새 String 생성 회피)
- \`QuestionDetailFeature.answerTextChanged\` (200자, 사용자 보고 케이스)
- \`GroupSelectFeature.groupNameChanged\` (10자)
- \`GroupSelectFeature.nicknameChanged\` (10자)

## 손대지 않은 곳
- \`GroupSelectFeature.joinCodeChanged\` (20자, 영문/숫자 전용)
- \`EmailSignupFeature.code\` (6자 숫자)

→ IME 조합 자체가 발생하지 않으므로 회생 없음.

## Test plan
- [x] xcodebuild iOS Simulator Debug → BUILD SUCCEEDED
- [ ] 시뮬레이터/실기기에서 답변 작성 화면에 한글 빠르게 입력 → \`오늘 기쁨\` 등이 회생 없이 표시되는지
- [ ] 그룹 만들기 / 닉네임 입력에서도 동일 검증
- [ ] 200자/10자 경계 입력 → truncate 동작 확인 (경계 넘을 땐 cursor 튐 허용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)