### PR TITLE
fix(ios-push): 알림 진입 시 홈 데이터 강제 새로고침 (MG-132)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -818,9 +818,13 @@ extension RootFeature {
                     // MG-116 — 알림 탭 등 외부 트리거로 그룹 home 으로 진입. mainTab.path 와 modal 을
                     // 비워 어떤 sub-screen 에 있었든 home 으로 복귀하게 한다. 미인증 상태 / 데이터 미로드
                     // 케이스는 자연스럽게 부팅 흐름이 home 까지 데려가므로 별도 pending 플래그 불필요.
+                    // MG-132 — path/modal 만 비울 뿐 데이터는 캐시 그대로라 다른 멤버의 답변 ✓ 가 반영되지
+                    // 않는 회귀가 있었다. 인증·데이터 로드 완료 상태일 때만 refreshHomeData 까지 함께
+                    // 트리거해 백그라운드 push 진입 시 즉시 최신화한다.
                     if state.appState == .authenticated {
                         state.mainTab?.modal = nil
                         state.mainTab?.path.removeAll()
+                        return .send(.refreshHomeData)
                     }
                     return .none
                 }


### PR DESCRIPTION
## Summary
- `.openHome` 케이스가 `mainTab.path/modal` 만 비우고 데이터는 캐시 그대로라, 백그라운드 푸시 알림 탭 진입 시 다른 멤버의 답변 ✓ 표시가 즉시 반영되지 않는 회귀.
- 인증·데이터 로드 완료 상태일 때만 `.refreshHomeData` 까지 함께 send.
- 부모 이슈: [MG-130](https://ycompany.atlassian.net/browse/MG-130) · 본 이슈: [MG-132](https://ycompany.atlassian.net/browse/MG-132)

## Test plan
- [ ] 시뮬레이터: 그룹 멤버가 답변 → 다른 단말이 백그라운드 상태에서 알림 탭 → 홈 진입 시 멤버 ✓ 즉시 표시
- [ ] 시뮬레이터: 다른 탭(예: 기록)에 있을 때 알림 탭 → 홈으로 라우팅되며 즉시 새 데이터 표시
- [ ] cold start (앱 종료 상태) 알림 탭 진입 회귀 없음
- [ ] 미인증 / 그룹 미생성 상태에서 `.openHome` 호출 시 `.refreshHomeData` 가 발사되지 않음을 TestStore 로 확인