### PR TITLE
fix(ios-ui): 탭바 라벨 i18n + Dynamic Type 영향 고정 (MG-134)

### DIFF
--- a/Mongle/MongleApp.swift
+++ b/Mongle/MongleApp.swift
@@ -149,6 +149,10 @@ struct MongleApp: App {
         }
 
         MongleFont.registerFonts()
+        // MG-134 — 탭바 라벨 폰트 사이즈를 명시 고정. SwiftUI `.dynamicTypeSize` modifier
+        // 가 tabItem 의 UITabBarItem 텍스트에는 적용되지 않아 UIKit appearance 로 직접
+        // 폰트를 박는다. 시스템 글자 크기를 키워도 탭바 라벨이 늘어나 레이아웃이 깨지지 않게.
+        Self.installTabBarAppearance()
         SocialSDK.initialize()
         // 서버 /config (MG-132) — 광고 토글 캐시 갱신. 동의 흐름보다 먼저 시작해
         // 다음 부팅부터 ConsentManager / AdBannerSection 분기에 최신값이 반영된다.
@@ -187,5 +191,28 @@ struct MongleApp: App {
                     }
                 }
         }
+    }
+}
+
+private extension MongleApp {
+    /// MG-134 — UITabBarItem 텍스트 폰트를 명시 고정.
+    /// SwiftUI `.dynamicTypeSize` modifier 가 `.tabItem` 라벨에는 적용되지 않아 UIKit
+    /// appearance 로 처리. 시스템 글자 크기를 키워도 탭바 라벨이 늘어나 레이아웃이
+    /// 깨지지 않도록 한다. 배경/색상은 SwiftUI `.toolbarBackground` 가 덮으므로 폰트만 지정.
+    static func installTabBarAppearance() {
+        let appearance = UITabBarAppearance()
+        let titleFont = UIFont.systemFont(ofSize: 10, weight: .medium)
+        let attrs: [NSAttributedString.Key: Any] = [.font: titleFont]
+        let layouts = [
+            appearance.stackedLayoutAppearance,
+            appearance.inlineLayoutAppearance,
+            appearance.compactInlineLayoutAppearance
+        ]
+        layouts.forEach { layout in
+            layout.normal.titleTextAttributes = attrs
+            layout.selected.titleTextAttributes = attrs
+        }
+        UITabBar.appearance().standardAppearance = appearance
+        UITabBar.appearance().scrollEdgeAppearance = appearance
     }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
@@ -81,16 +81,16 @@ struct MainTabView: View {
         TabView(selection: $store.selectedTab.sending(\.selectTab)) {
             homeTab
             HistoryView(store: store.scope(state: \.history, action: \.history))
-                .tabItem { Label("HISTORY", systemImage: "book") }
+                .tabItem { Label(L10n.tr("tab_history"), systemImage: "book") }
                 .tag(MainTabFeature.State.Tab.history)
             SearchHistoryView(store: store.scope(state: \.search, action: \.search))
-                .tabItem { Label("SEARCH", systemImage: "magnifyingglass") }
+                .tabItem { Label(L10n.tr("tab_search"), systemImage: "magnifyingglass") }
                 .tag(MainTabFeature.State.Tab.search)
 //            NotificationView(store: store.scope(state: \.notification, action: \.notification))
 //                .tabItem { Label("NOTICE", systemImage: "bell") }
 //                .tag(MainTabFeature.State.Tab.notification)
             ProfileEditView(store: store.scope(state: \.profile, action: \.profile))
-                .tabItem { Label("MY", systemImage: "person") }
+                .tabItem { Label(L10n.tr("tab_my"), systemImage: "person") }
                 .tag(MainTabFeature.State.Tab.settings)
         }
         .accentColor(MongleColor.primaryDeep)
@@ -121,7 +121,7 @@ struct MainTabView: View {
         }
         .toolbarBackground(Color.white, for: .tabBar)
         .toolbarBackground(.visible, for: .tabBar)
-        .tabItem { Label("HOME", systemImage: "house") }
+        .tabItem { Label(L10n.tr("tab_home"), systemImage: "house") }
         .tag(MainTabFeature.State.Tab.home)
     }
 

--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -458,3 +458,9 @@
 "error_ad_load_failed" = "Couldn't load the ad. Please try again.";
 "error_already_answered_skip" = "You can't skip a question you've already answered";
 "error_already_skipped" = "You've already skipped this question";
+
+/* Main Tab (MG-134) */
+"tab_home" = "Home";
+"tab_history" = "History";
+"tab_search" = "Search";
+"tab_my" = "My";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -458,3 +458,9 @@
 "error_ad_load_failed" = "広告を読み込めませんでした。もう一度お試しください。";
 "error_already_answered_skip" = "既に回答した質問はスキップできません";
 "error_already_skipped" = "既にこの質問をスキップしました";
+
+/* Main Tab (MG-134) */
+"tab_home" = "ホーム";
+"tab_history" = "履歴";
+"tab_search" = "検索";
+"tab_my" = "マイ";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -458,3 +458,9 @@
 "error_ad_load_failed" = "광고를 불러올 수 없어요. 다시 시도해주세요.";
 "error_already_answered_skip" = "이미 답변한 질문은 넘길 수 없어요";
 "error_already_skipped" = "이미 질문을 넘겼어요";
+
+/* Main Tab (MG-134) */
+"tab_home" = "홈";
+"tab_history" = "기록";
+"tab_search" = "검색";
+"tab_my" = "내 정보";


### PR DESCRIPTION
## Summary
- 탭바 라벨이 영어 하드코딩이라 시스템 언어 설정 무관하게 영어로만 표시 → `L10n.tr("tab_*")` 로 교체하고 ko/en/ja `Localizable.strings` 에 키 추가
- 사용자가 OS 글자 크기를 키우면 탭바 라벨까지 함께 커져 레이아웃이 깨짐 → `UITabBarAppearance.stackedLayoutAppearance.normal/selected.titleTextAttributes` 에 10pt medium 시스템 폰트 명시 고정 (`.dynamicTypeSize` modifier 는 `.tabItem` 라벨에 적용되지 않음)
- 이슈: [MG-134](https://ycompany.atlassian.net/browse/MG-134)

## Test plan
- [ ] 기기 언어 한/영/일 전환 → 탭바 4개 라벨 (홈/기록/검색/내 정보) 즉시 해당 언어 표시
- [ ] 설정 → 디스플레이 → 텍스트 크기를 가장 크게 → 탭바 라벨 크기 변화 없음
- [ ] 기본 글자 크기에서도 시각적 회귀 없음 (10pt medium 가독성)
- [ ] `.toolbarBackground(Color.white, for: .tabBar)` 설정이 여전히 작동 (배경 흰색 유지)