### PR TITLE
fix(ios-ui): 탭바 네번째 라벨 → '설정/Settings/設定' 통일 (MG-136)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -463,4 +463,4 @@
 "tab_home" = "Home";
 "tab_history" = "History";
 "tab_search" = "Search";
-"tab_my" = "My";
+"tab_my" = "Settings";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -463,4 +463,4 @@
 "tab_home" = "ホーム";
 "tab_history" = "履歴";
 "tab_search" = "検索";
-"tab_my" = "マイ";
+"tab_my" = "設定";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -463,4 +463,4 @@
 "tab_home" = "홈";
 "tab_history" = "기록";
 "tab_search" = "검색";
-"tab_my" = "내 정보";
+"tab_my" = "설정";


### PR DESCRIPTION
## Summary
- 탭바 네번째 라벨이 가리키는 화면이 계정/그룹/환경 설정이라 'My' 보다 'Settings' 가 사용자 멘탈 모델과 일치
- ko: 내 정보 → **설정**
- en: My → **Settings**
- ja: マイ → **設定**
- 키 이름(`tab_my`)은 그대로 — 코드 변경 없음
- 이슈: [MG-136](https://ycompany.atlassian.net/browse/MG-136)

## Test plan
- [ ] 기기 언어 한/영/일 모두 네번째 탭에 새 라벨 표시
- [ ] 글자 크기 최대 시 레이아웃 회귀 없음