### PR TITLE
fix(ios-ui): 광고 OFF 시 광고 자리 빈 공간 제거 (MG-139)

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Common/AdBannerView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Common/AdBannerView.swift
@@ -24,11 +24,25 @@ public struct AdBannerView: UIViewRepresentable {
 // MARK: - 배너 섹션 레이아웃 (Settings 화면의 "후원" 섹션과 동일한 스타일)
 
 public struct AdBannerSection: View {
-    public init() {}
+    private let topPadding: CGFloat
+    private let bottomPadding: CGFloat
+    private let horizontalPadding: CGFloat
+
+    public init(
+        top: CGFloat = 0,
+        bottom: CGFloat = 0,
+        horizontal: CGFloat = 0
+    ) {
+        self.topPadding = top
+        self.bottomPadding = bottom
+        self.horizontalPadding = horizontal
+    }
 
     public var body: some View {
         // 서버 /config (MG-132) — 비활성 시 layout 공간도 차지하지 않도록 EmptyView 반환.
-        // 호출자 (Settings/Home/History 등) 의 분기 코드는 불필요.
+        // padding 은 호출자가 외부 modifier 로 붙이면 ModifiedContent 가 항상 emit 되어
+        // 부모 VStack 의 자식 슬롯이 잡혀 빈 공간이 남는다. 그래서 padding 도 본 구조체가
+        // 인자로 받아 if 블록 안에서 적용 — Android 의 early return 과 동일한 효과 (MG-139).
         if AdConfigStore.isAdEnabled {
             VStack(alignment: .leading, spacing: 8) {
                 AdBannerView()
@@ -37,6 +51,9 @@ public struct AdBannerSection: View {
                     .background(Color(hex: "#F5F5F5"))
                     .clipShape(RoundedRectangle(cornerRadius: MongleRadius.large))
             }
+            .padding(.top, topPadding)
+            .padding(.bottom, bottomPadding)
+            .padding(.horizontal, horizontalPadding)
         }
     }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectView+Select.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Group/GroupSelectView+Select.swift
@@ -81,8 +81,7 @@ extension GroupSelectView {
 
       #if os(iOS)
       if !store.groups.isEmpty {
-        AdBannerSection()
-          .padding(.top, MongleSpacing.sm)
+        AdBannerSection(top: MongleSpacing.sm)
       }
       #endif
     }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/ProfileEditView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/ProfileEditView.swift
@@ -28,9 +28,7 @@ public struct ProfileEditView: View {
                         
                       // 광고 배너
                         #if os(iOS)
-                        AdBannerSection()
-                            .padding(.horizontal, 20)
-                            .padding(.bottom, 4)
+                        AdBannerSection(bottom: 4, horizontal: 20)
                         #endif
 
                         moodSection

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Search/SearchHistoryView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Search/SearchHistoryView.swift
@@ -140,9 +140,7 @@ public struct SearchHistoryView: View {
 
                         if adAnchors.contains(result.id) {
                             #if os(iOS)
-                            AdBannerSection()
-                                .padding(.horizontal, 20)
-                                .padding(.bottom, MongleSpacing.sm)
+                            AdBannerSection(bottom: MongleSpacing.sm, horizontal: 20)
                             #endif
                         }
                     }


### PR DESCRIPTION
## Summary
- 서버 `/config`의 `isAdEnabled: false`일 때 iOS만 광고 자리 UI가 남던 회귀 차단 (Android는 정상).
- 원인: `AdBannerSection()` 호출 사이트 3곳이 외부에 `.padding(...)` 를 붙여 `ModifiedContent`로 wrap → false 일 때도 부모 VStack 의 자식 슬롯이 잡혀 spacing 만큼 빈 공간이 발생.
- Fix: `AdBannerSection`이 `top` / `bottom` / `horizontal` padding 을 인자로 받아 `if AdConfigStore.isAdEnabled { ... }` 블록 안에서 적용. 호출 사이트는 외부 modifier 제거.

## 변경 파일
- `MongleFeatures/Sources/.../Common/AdBannerView.swift` — init 에 padding 파라미터 추가, if 블록 안에서 적용
- `MongleFeatures/Sources/.../Group/GroupSelectView+Select.swift` — `AdBannerSection(top: MongleSpacing.sm)`
- `MongleFeatures/Sources/.../Search/SearchHistoryView.swift` — `AdBannerSection(bottom: MongleSpacing.sm, horizontal: 20)`
- `MongleFeatures/Sources/.../Profile/ProfileEditView.swift` — `AdBannerSection(bottom: 4, horizontal: 20)`
- `SettingsTabView.swift` — 외부 modifier 없어 변경 없음

## 대조
- Android `Mongle-Android/.../ui/common/AdBannerView.kt:30` 의 `if (!AdConfigStore.read(...)) return` 과 동일한 사상 — banner 자체가 emit 되지 않도록 처리.

## Jira
- https://ycompany.atlassian.net/browse/MG-139

## Test plan
- [ ] 서버 `/config` 에서 `isAdEnabled: false` 인 상태로 부팅
- [ ] Settings · GroupSelect · Search · ProfileEdit 4 개 화면 모두에서 광고 자리에 빈 공간 없는지 확인
- [ ] `isAdEnabled: true` 회귀: 4 개 화면에서 padding 이 기존과 동일하게 적용되는지 확인
- [ ] V2 (feature/v2-design-home-shop) 브랜치로 머지 후에도 같은 동작 유지하는지 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)