### PR TITLE
fix(ios-push): 디바이스 토큰 등록이 강제 로그아웃을 유발하지 않도록 분리 (MG-141)

### DIFF
--- a/MongleData/Sources/MongleData/DataSources/Remote/API/APIClient.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/API/APIClient.swift
@@ -11,6 +11,10 @@ public extension Notification.Name {
 protocol APIClientProtocol: Sendable {
     func request<T: Decodable>(_ endpoint: APIEndpoint) async throws -> T
     func request(_ endpoint: APIEndpoint) async throws
+    /// (MG-141) sessionExpired 강제 로그아웃 신호를 억제하는 변형.
+    /// 디바이스 토큰 등록처럼 백그라운드/비핵심 요청이 일시적 401→refresh 실패로
+    /// 사용자를 의도치 않게 로그아웃시키지 않도록 한다. 핵심 요청은 기본(escalate=true) 사용.
+    func request<T: Decodable>(_ endpoint: APIEndpoint, escalateSessionExpired: Bool) async throws -> T
 }
 
 // MARK: - Token Refresh Actor (동시 갱신 방지)
@@ -88,6 +92,10 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
     // MARK: - Request with Response
 
     func request<T: Decodable>(_ endpoint: APIEndpoint) async throws -> T {
+        try await request(endpoint, escalateSessionExpired: true)
+    }
+
+    func request<T: Decodable>(_ endpoint: APIEndpoint, escalateSessionExpired: Bool) async throws -> T {
         try checkConnectivity()
         return try await withRetry(label: "\(type(of: endpoint))") {
             var urlRequest = try endpoint.buildURLRequest()
@@ -96,7 +104,7 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
 
             // 401 → 리프레시 토큰으로 갱신 후 1회 재시도
             if response.statusCode == 401 {
-                let newToken = try await self.attemptTokenRefresh()
+                let newToken = try await self.attemptTokenRefresh(escalateSessionExpired: escalateSessionExpired)
                 var retryRequest = try endpoint.buildURLRequest()
                 retryRequest.setValue("Bearer \(newToken)", forHTTPHeaderField: "Authorization")
                 let (retryData, retryResponse) = try await self.perform(retryRequest)
@@ -209,7 +217,7 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
     /// 단, 처음부터 refresh 토큰이 아예 없는 케이스(첫 install / 로그아웃 직후) 는
     /// "세션이 만료된" 게 아니라 "세션이 한 번도 없었던" 상태이므로 mongleSessionExpired
     /// 신호를 post 하지 않는다 (불필요한 "다시 로그인 필요" 팝업 차단).
-    private func attemptTokenRefresh() async throws -> String {
+    private func attemptTokenRefresh(escalateSessionExpired: Bool = true) async throws -> String {
         let hadRefreshTokenBefore = tokenStorage.getRefreshToken() != nil
         do {
             return try await refreshCoordinator.refresh {
@@ -241,7 +249,9 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
             // "만료된" 게 아니라 "한 번도 없었던" 상태. 이 경우 sessionExpired 팝업을
             // 띄우는 건 사용자에게 혼란만 준다. RootFeature 가 onAppear 에서 user=nil 을
             // 받아 자연스럽게 LoginView 로 라우팅하면 되므로 신호를 post 하지 않는다.
-            if hadRefreshTokenBefore {
+            // (MG-141) escalateSessionExpired=false 인 백그라운드 요청(디바이스 토큰 등록 등)도
+            // 강제 로그아웃을 일으키지 않는다 — 토큰 등록 실패로 가족 연결이 끊기는 것을 방지.
+            if hadRefreshTokenBefore && escalateSessionExpired {
                 await MainActor.run {
                     NotificationCenter.default.post(name: .mongleSessionExpired, object: nil)
                 }
@@ -287,6 +297,10 @@ final class MockAPIClient: APIClientProtocol, @unchecked Sendable {
             throw APIError.decodingError("Mock response type mismatch")
         }
         return response
+    }
+
+    func request<T: Decodable>(_ endpoint: APIEndpoint, escalateSessionExpired: Bool) async throws -> T {
+        try await request(endpoint)
     }
 
     func request(_ endpoint: APIEndpoint) async throws {

--- a/MongleData/Sources/MongleData/Repositories/UserRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/UserRepository.swift
@@ -41,7 +41,12 @@ final class UserRepository: UserRepositoryInterface {
 
     func registerDeviceToken(token: String, environment: String) async throws {
         struct OkResponse: Decodable { let ok: Bool }
-        let _: OkResponse = try await apiClient.request(UserEndpoint.registerDeviceToken(token: token, environment: environment))
+        // (MG-141) 디바이스 토큰 등록은 백그라운드/비핵심 요청 — 401→refresh 실패해도 강제 로그아웃(sessionExpired)
+        // 신호를 내지 않는다. 토큰 등록 실패가 "의도치 않은 로그아웃 → 재촉 푸시 누락"으로 번지는 것을 차단.
+        let _: OkResponse = try await apiClient.request(
+            UserEndpoint.registerDeviceToken(token: token, environment: environment),
+            escalateSessionExpired: false
+        )
     }
 
     func grantAdHearts(amount: Int) async throws -> Int {

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Root/Ext/Root+Reducer.swift
@@ -393,6 +393,10 @@ extension RootFeature {
                 case .sessionExpired:
                     // APIClient 가 이미 토큰을 폐기했으므로 authRepository.logout() 호출 불필요.
                     // .logout cleanup 패턴 재사용 + 안내 팝업 플래그 set.
+                    // (MG-141) 의도적으로 authRepository.logout() 을 호출하지 않는다 — 서버 /auth/logout 은
+                    // 디바이스 토큰을 보존(soft logout)하지만, 세션만료는 그 호출조차 없이 서버가 refresh 실패
+                    // 시점에 sessionState='expired' 로만 내려 토큰을 남긴다. 이 토큰으로 "다시 로그인" 재참여
+                    // 푸시가 발송되어 가족 연결이 유지된다. 여기서 logout 을 부르면 그 경로가 끊기니 추가 금지.
                     state.showSessionExpiredPopup = true
                     state.appState = .unauthenticated
                     state.currentUser = nil


### PR DESCRIPTION
## 배경
서버 PR(rrheon/Mongle-Server#70, MG-141)에서 **디바이스 토큰을 인증 세션에서 분리(소프트 로그아웃)** 하여 로그아웃/세션만료에도 토큰을 보존하고 "다시 로그인" 재참여 푸시를 보낼 수 있게 했다. 이 PR은 iOS 측 정합.

## 문제
iOS `APIClient.attemptTokenRefresh` 는 refresh 실패 시 **모든 요청**에 대해 `mongleSessionExpired`(강제 로그아웃)를 broadcast 한다. 그래서 **디바이스 토큰 등록** 같은 백그라운드/비핵심 요청이 일시적 401→refresh 실패를 만나면 사용자를 의도치 않게 로그아웃시키고, 그 결과 재촉 푸시가 끊겨 가족 연결이 단절될 수 있다.

## 변경
- **APIClient**: `request(_, escalateSessionExpired:)` 변형 추가. `false` 면 refresh 실패해도 `mongleSessionExpired` 를 post 하지 않는다. 핵심 요청은 기본 `true` 로 기존 동작 유지.
- **UserRepository.registerDeviceToken**: `escalateSessionExpired: false` 로 호출 → 토큰 등록 실패가 강제 로그아웃으로 번지지 않음.
- **Root+Reducer `.sessionExpired`**: 소프트 로그아웃 계약 명문화 — 여기서 `authRepository.logout()` 을 호출하면 서버 토큰이 지워져 재참여 푸시 경로가 끊기므로 **추가 금지** 주석.
- **MockAPIClient**: 새 시그니처 대응.

## 동작 정합 (서버와)
- 명시적 로그아웃: iOS `/auth/logout` 호출 → 서버가 토큰 보존 + `logged_out`. ✅ 변경 불필요(서버가 처리).
- 세션만료: iOS 가 refresh 시도 → 서버 `refreshToken` 실패 시점에 `sessionState='expired'` 마킹 → 토큰 보존. iOS 는 logout 미호출(기존+명문화). ✅
- 재로그인: 서버 `issueTokensForUser` 가 `active` 복귀 → 콘텐츠 푸시 재개. ✅

## 테스트
- `MongleFeatures` 스킴(→ MongleData/Domain 포함) **BUILD SUCCEEDED**.
- 추가한 프로토콜 메서드에 영향받는 테스트 mock 없음(APIClientProtocol 구현체는 APIClient/MockAPIClient 뿐).
- 스킴이 test action 미구성이라 유닛테스트 실행은 프로젝트 표준 경로 밖 — 빌드 + mock 영향 분석으로 검증.

## 후속
Android(MVI): 서버 logout 호출 통일, `FirebaseMessaging.deleteToken()` 제거(토큰 보존), `onNewToken` 즉시 등록. 설계: `Work.md`.

Jira: MG-141 · 서버 PR: rrheon/Mongle-Server#70

🤖 Generated with [Claude Code](https://claude.com/claude-code)