### PR TITLE
fix(shop): 새틴 리본 미리보기 크기를 다른 장식과 통일

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/DecorationCatalog.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/DecorationCatalog.swift
@@ -89,7 +89,7 @@ enum DecorationCatalog {
         // 56×56 슬롯을 세로로 넘쳐(다른 셀보다 커 보임/셀 침범) 버린다. 여기선 자산을 양쪽 모두
         // 제약된 정사각 박스에 scaledToFit 시켜 절대 넘치지 않고 다른 장식과 크기를 맞춘다.
         case satinRibbon:
-            Image("V2Ribbon", bundle: .module).resizable().scaledToFit().frame(width: 50, height: 50)
+            Image("V2Ribbon", bundle: .module).resizable().scaledToFit().frame(width: 44, height: 44)
         case balloonBunch: V2BalloonBunch()
         case santaHat:     V2SantaHat()
         case angelWings:   V2AngelWings(size: 56)


### PR DESCRIPTION
## 문제
꾸미기 그리드에서 셀(카드) 자체는 균일하나, **새틴 리본 그래픽이 50 박스를 꽉 채워** 다른 장식(화관/후광 등)보다 시각적으로 크게 보임.

## 수정
리본을 고정 박스 **44×44** 에 `scaledToFit` → 이미지 비율로 커지지 않고 다른 장식과 동일한 footprint. (이미지 크기 기준이 아니라 고정 크기 기준)

## 검증
시뮬레이터 `ImageRenderer` 스냅샷 — 5종(화관/후광/리본/풍선/산타) 시각 크기 균일 확인.

⚠️ iOS UI 변경이므로 **앱 재빌드 필요** (서버 재배포로는 반영 안 됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)