### PR TITLE
fix(shop): 보유한 장식에 '보유중' 배지 표시

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopView.swift
@@ -252,7 +252,8 @@ struct ShopView: View {
                     V2DecoTile(
                         name: item.name,
                         price: owned ? nil : "\(item.price)",
-                        equipped: equipped
+                        equipped: equipped,
+                        owned: owned
                     ) {
                         DecorationCatalog.preview(for: item.id)
                     }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/V2/V2ShopScreens.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/V2/V2ShopScreens.swift
@@ -211,6 +211,7 @@ struct V2DecoTile<Preview: View>: View {
     var name: String
     var price: String? = nil
     var equipped: Bool = false
+    var owned: Bool = false
     @ViewBuilder var preview: () -> Preview
 
     var body: some View {
@@ -231,12 +232,18 @@ struct V2DecoTile<Preview: View>: View {
         .shadow(color: .black.opacity(0.06), radius: 5, y: 2)
     }
 
-    // 상태 라벨 — 장착중(민트 배지) / 가격(하트+숫자) / 없음(빈 영역). 고정 높이 컨테이너 안에 둔다.
+    // 상태 라벨 — 장착중(민트) / 보유중(중립 회색) / 가격(하트+숫자) / 없음(빈 영역).
+    // 보유중을 가격보다 우선해, 이미 산 장식은 가격 대신 "보유중"을 보여준다(배경 타일과 동일 정책).
+    // 고정 높이 컨테이너 안에 둔다.
     @ViewBuilder private var statusLabel: some View {
         if equipped {
             Text("장착중").font(V2Font.suit(10, .heavy)).foregroundStyle(V2Palette.ink)
                 .padding(.horizontal, 10).padding(.vertical, 3)
                 .background(V2Palette.mint, in: Capsule())
+        } else if owned {
+            Text("보유중").font(V2Font.suit(10, .heavy)).foregroundStyle(V2Palette.muted)
+                .padding(.horizontal, 10).padding(.vertical, 3)
+                .background(V2Palette.ink.opacity(0.06), in: Capsule())
         } else if let price {
             HStack(spacing: 4) {
                 Image(systemName: "heart.fill").font(.system(size: 12)).foregroundStyle(V2Palette.heartPink)


### PR DESCRIPTION
## 문제
"새틴 리본만 가격이 안 보인다"는 제보 — 확인 결과 **서버 가격은 정상**(catalog `deco_satin_ribbon` price 50, prod DB에서도 확인). 실제 원인은 iOS 표시 로직: 장식 타일은 **미보유→가격 / 장착→"장착중"** 만 있고 **'보유(미장착)' 상태가 없어 빈칸**이 됨. 테스트 중 새틴 리본을 구매(보유)해 가격이 숨겨진 상태였음.

## 수정
`V2DecoTile` 에 `owned` 상태 추가 → 보유한 장식은 가격 대신 **"보유중"** 배지 표시(배경 타일과 동일 정책). 우선순위: 장착중 > 보유중 > 가격.

## 검증
시뮬레이터 `ImageRenderer` 스냅샷 — 미보유(♥50) / 보유("보유중") / 장착("장착중") 3상태 정상 표시 확인.

⚠️ iOS UI 변경 — 앱 재빌드 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)