### PR TITLE
feat(shop): 장식 착용 모델 단일화 (전체 1개 착용)

### DIFF
--- a/Domain/Sources/Domain/Entities/Shop.swift
+++ b/Domain/Sources/Domain/Entities/Shop.swift
@@ -58,43 +58,22 @@ public struct ShopItem: Identifiable, Equatable, Hashable, Sendable {
     }
 }
 
-/// 슬롯별 현재 장착된 장식 id. nil 이면 해당 슬롯에 아무것도 장착하지 않음(장식 없음).
-public struct EquippedDecorations: Equatable, Sendable {
-    public var head: String?
-    public var back: String?
-    public var feet: String?
-
-    public init(head: String? = nil, back: String? = nil, feet: String? = nil) {
-        self.head = head
-        self.back = back
-        self.feet = feet
-    }
-
-    /// 슬롯 단위 접근 헬퍼.
-    public func id(for slot: DecorationSlot) -> String? {
-        switch slot {
-        case .head: return head
-        case .back: return back
-        case .feet: return feet
-        }
-    }
-}
-
 /// 사용자의 상점 보유/장착 현황.
 public struct ShopInventory: Equatable, Sendable {
     public var ownedDecorationIds: Set<String>
-    public var equippedDecorations: EquippedDecorations
+    /// 현재 장착 중인 꾸미기 1개(전역 단일). nil = 미착용. slot 은 카탈로그 item.slot 에서 조회.
+    public var equippedDecorationId: String?
     public var ownedBackgroundIds: Set<String>
     public var appliedBackgroundId: String?
 
     public init(
         ownedDecorationIds: Set<String> = [],
-        equippedDecorations: EquippedDecorations = EquippedDecorations(),
+        equippedDecorationId: String? = nil,
         ownedBackgroundIds: Set<String> = [],
         appliedBackgroundId: String? = nil
     ) {
         self.ownedDecorationIds = ownedDecorationIds
-        self.equippedDecorations = equippedDecorations
+        self.equippedDecorationId = equippedDecorationId
         self.ownedBackgroundIds = ownedBackgroundIds
         self.appliedBackgroundId = appliedBackgroundId
     }

--- a/Domain/Sources/Domain/Entities/User.swift
+++ b/Domain/Sources/Domain/Entities/User.swift
@@ -21,9 +21,9 @@ public struct User: Identifiable, Equatable, Sendable {
     /// 띄운다 (UserDefaults 자체 카운터 제거, MG-77). opt-in 미포함 호출
     /// (QuestionDetail/ProfileEdit hearts sync 등)에서는 항상 false.
     public let heartGrantedToday: Bool
-    /// 사용자가 현재 슬롯별로 장착한 장식. 상점(Shop) 기능에서 사용한다.
+    /// 사용자가 현재 장착한 꾸미기 1개(전역 단일). nil = 미착용. 상점(Shop) 기능에서 사용한다.
     /// 후행 파라미터 + 기본값으로 두어 기존 호출부에는 영향이 없다.
-    public let equippedDecorations: EquippedDecorations
+    public let equippedDecorationId: String?
 
     public init(
         id: UUID,
@@ -35,7 +35,7 @@ public struct User: Identifiable, Equatable, Sendable {
         moodId: String? = "loved",
         createdAt: Date,
         heartGrantedToday: Bool = false,
-        equippedDecorations: EquippedDecorations = EquippedDecorations()
+        equippedDecorationId: String? = nil
     ) {
         self.id = id
         self.email = email
@@ -46,7 +46,7 @@ public struct User: Identifiable, Equatable, Sendable {
         self.moodId = moodId
         self.createdAt = createdAt
         self.heartGrantedToday = heartGrantedToday
-        self.equippedDecorations = equippedDecorations
+        self.equippedDecorationId = equippedDecorationId
     }
 }
 

--- a/Domain/Sources/Domain/Repositories/ShopRepositoryProtocol.swift
+++ b/Domain/Sources/Domain/Repositories/ShopRepositoryProtocol.swift
@@ -16,8 +16,8 @@ public protocol ShopRepositoryInterface: Sendable {
     func getInventory() async throws -> ShopInventory
     /// 아이템 구매. 서버가 하트 차감 후 남은 하트 수를 반환한다.
     func purchase(itemId: String) async throws -> Int
-    /// 슬롯에 장식을 장착(itemId)하거나 해제(nil)한다. 갱신된 장착 현황을 반환.
-    func equipDecoration(slot: DecorationSlot, itemId: String?) async throws -> EquippedDecorations
+    /// 꾸미기를 장착(itemId)하거나 해제(nil)한다. 갱신된 장착 id(미착용 nil)를 반환.
+    func equipDecoration(itemId: String?) async throws -> String?
     /// 가족 공유 홈 배경을 적용한다. 갱신된 보유/적용 현황을 반환.
     /// 구매는 기존 purchase(서버 권위) 를 재사용하고, 적용만 이 메서드가 담당한다.
     func applyBackground(itemId: String) async throws -> ShopInventory

--- a/MongleData/Sources/MongleData/DTOs/ShopDTO.swift
+++ b/MongleData/Sources/MongleData/DTOs/ShopDTO.swift
@@ -20,17 +20,10 @@ struct ShopItemDTO: Decodable {
     let sortOrder: Int?
 }
 
-/// 슬롯별 장착 장식 id.
-struct EquippedDecorationsDTO: Decodable {
-    let head: String?
-    let back: String?
-    let feet: String?
-}
-
 /// 사용자 보유/장착 현황.
 struct ShopInventoryDTO: Decodable {
     let ownedDecorationIds: [String]?
-    let equippedDecorations: EquippedDecorationsDTO?
+    let equippedDecorationId: String?
     let ownedBackgroundIds: [String]?
     let appliedBackgroundId: String?
 }
@@ -40,7 +33,7 @@ struct PurchaseResponseDTO: Decodable {
     let heartsRemaining: Int
 }
 
-/// 장착 응답. 갱신된 장착 현황을 반환한다.
+/// 장착 응답. 갱신된 장착 id(미착용 시 키 생략)를 반환한다.
 struct EquipResponseDTO: Decodable {
-    let equippedDecorations: EquippedDecorationsDTO?
+    let equippedDecorationId: String?
 }

--- a/MongleData/Sources/MongleData/DataSources/Remote/API/APIEndpoint.swift
+++ b/MongleData/Sources/MongleData/DataSources/Remote/API/APIEndpoint.swift
@@ -665,8 +665,8 @@ enum ShopEndpoint: APIEndpoint {
     case getInventory
     /// POST /shop/purchase — 아이템 구매 (서버가 하트 차감 후 잔액 반환).
     case purchase(itemId: String)
-    /// POST /shop/decoration/equip — 슬롯에 장식 장착/해제.
-    case equipDecoration(slot: String, itemId: String?)
+    /// POST /shop/decoration/equip — 꾸미기 장착(itemId)/해제(nil).
+    case equipDecoration(itemId: String?)
     /// POST /shop/background/apply — 가족 공유 홈 배경 적용.
     case applyBackground(itemId: String)
 
@@ -693,8 +693,8 @@ enum ShopEndpoint: APIEndpoint {
         switch self {
         case .purchase(let itemId):
             return try? JSONSerialization.data(withJSONObject: ["itemId": itemId])
-        case .equipDecoration(let slot, let itemId):
-            var params: [String: Any] = ["slot": slot]
+        case .equipDecoration(let itemId):
+            var params: [String: Any] = [:]
             if let itemId { params["itemId"] = itemId }
             return try? JSONSerialization.data(withJSONObject: params)
         case .applyBackground(let itemId):

--- a/MongleData/Sources/MongleData/Mappers/ShopMapper.swift
+++ b/MongleData/Sources/MongleData/Mappers/ShopMapper.swift
@@ -22,14 +22,10 @@ struct ShopMapper {
         )
     }
 
-    static func toDomain(_ dto: EquippedDecorationsDTO?) -> EquippedDecorations {
-        EquippedDecorations(head: dto?.head, back: dto?.back, feet: dto?.feet)
-    }
-
     static func toDomain(_ dto: ShopInventoryDTO) -> ShopInventory {
         ShopInventory(
             ownedDecorationIds: Set(dto.ownedDecorationIds ?? []),
-            equippedDecorations: toDomain(dto.equippedDecorations),
+            equippedDecorationId: dto.equippedDecorationId,
             ownedBackgroundIds: Set(dto.ownedBackgroundIds ?? []),
             appliedBackgroundId: dto.appliedBackgroundId
         )

--- a/MongleData/Sources/MongleData/Repositories/ShopRepository.swift
+++ b/MongleData/Sources/MongleData/Repositories/ShopRepository.swift
@@ -32,11 +32,11 @@ final class ShopRepository: ShopRepositoryInterface {
         return response.heartsRemaining
     }
 
-    func equipDecoration(slot: DecorationSlot, itemId: String?) async throws -> EquippedDecorations {
+    func equipDecoration(itemId: String?) async throws -> String? {
         let response: EquipResponseDTO = try await apiClient.request(
-            ShopEndpoint.equipDecoration(slot: slot.rawValue, itemId: itemId)
+            ShopEndpoint.equipDecoration(itemId: itemId)
         )
-        return ShopMapper.toDomain(response.equippedDecorations)
+        return response.equippedDecorationId
     }
 
     // TODO(server): /shop/background/apply 미구현 — 응답은 갱신된 ShopInventory 를 가정한다.

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/Ext/MainTab+Reducer.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/Ext/MainTab+Reducer.swift
@@ -224,7 +224,7 @@ extension MainTabFeature {
                         hearts: state.home.hearts,
                         inventory: state.home.currentUser.map {
                             ShopInventory(
-                                equippedDecorations: $0.equippedDecorations,
+                                equippedDecorationId: $0.equippedDecorationId,
                                 ownedBackgroundIds: appliedBg.map { [$0] } ?? [],
                                 appliedBackgroundId: appliedBg
                             )
@@ -443,7 +443,7 @@ extension MainTabFeature {
                     state.home.hearts = hearts
                     return .none
 
-                case .path(.element(id: _, action: .shop(.delegate(.decorationsChanged(let decorations))))):
+                case .path(.element(id: _, action: .shop(.delegate(.decorationsChanged(let decorationId))))):
                     // 본인 currentUser 의 장착 장식을 갱신해 홈 캐릭터에 즉시 반영.
                     if let current = state.home.currentUser {
                         let updated = User(
@@ -456,7 +456,7 @@ extension MainTabFeature {
                             moodId: current.moodId,
                             createdAt: current.createdAt,
                             heartGrantedToday: current.heartGrantedToday,
-                            equippedDecorations: decorations
+                            equippedDecorationId: decorationId
                         )
                         state.home.currentUser = updated
                         if let idx = state.home.familyMembers.firstIndex(where: { $0.id == updated.id }) {
@@ -568,7 +568,7 @@ extension MainTabFeature {
                             moodId: moodId,
                             createdAt: current.createdAt,
                             // 수동 재구성 시 신규 필드 누락(silent drop) 방지 — 기존 값 보존.
-                            equippedDecorations: current.equippedDecorations
+                            equippedDecorationId: current.equippedDecorationId
                         )
                     }()
                     if let updated = updatedUser {
@@ -622,7 +622,7 @@ extension MainTabFeature {
                             moodId: moodId,
                             createdAt: current.createdAt,
                             // 수동 재구성 시 신규 필드 누락(silent drop) 방지 — 기존 값 보존.
-                            equippedDecorations: current.equippedDecorations
+                            equippedDecorationId: current.equippedDecorationId
                         )
                     }()
                     if let updated = editUpdatedUser {

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
@@ -191,6 +191,8 @@ struct MainTabView: View {
             .map { index, user in
                 let isCurrentUser = user.id == currentUserId
                 let moodId = isCurrentUser ? (store.previewMoodId ?? store.currentUserMoodId ?? user.moodId) : user.moodId
+                let eqId = isCurrentUser ? store.home.currentUser?.equippedDecorationId : nil
+                let eqSlot = DecorationCatalog.slotForItem(eqId)
                 return MongleMember(
                     id: user.id,
                     name: user.name,
@@ -198,11 +200,11 @@ struct MainTabView: View {
                     moodId: moodId,
                     hasAnswered: store.home.memberAnswerStatus[user.id] ?? false,
                     hasSkipped: store.home.memberSkippedStatus[user.id] ?? false,
-                    // 본인 멤버만 머리/등/발밑 장식 주입 (타인 장식 동기화는 후속). 상점에서
-                    // 장착 시 decorationsChanged delegate 가 currentUser 를 갱신해 즉시 반영된다.
-                    headDecorationId: isCurrentUser ? store.home.currentUser?.equippedDecorations.head : nil,
-                    backDecorationId: isCurrentUser ? store.home.currentUser?.equippedDecorations.back : nil,
-                    feetDecorationId: isCurrentUser ? store.home.currentUser?.equippedDecorations.feet : nil
+                    // 본인 멤버만 전역 단일 착용 1개를 그 장식의 슬롯 자리에 주입 (타인 동기화는 후속).
+                    // 상점 장착 시 decorationsChanged delegate 가 currentUser 를 갱신해 즉시 반영된다.
+                    headDecorationId: eqSlot == .head ? eqId : nil,
+                    backDecorationId: eqSlot == .back ? eqId : nil,
+                    feetDecorationId: eqSlot == .feet ? eqId : nil
                 )
             }
         return HomeViewV2(

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/MongleCardEditFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Profile/MongleCardEditFeature.swift
@@ -84,7 +84,7 @@ public struct MongleCardEditFeature {
                     moodId: moodId,
                     createdAt: user.createdAt,
                     // 수동 재구성 시 신규 필드 누락(silent drop) 방지 — 기존 값 보존.
-                    equippedDecorations: user.equippedDecorations
+                    equippedDecorationId: user.equippedDecorationId
                 )
                 return .run { send in
                     do {

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/DecorationCatalog.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/DecorationCatalog.swift
@@ -134,6 +134,12 @@ enum DecorationCatalog {
         }
     }
 
+    /// 단일 장착 id → 그 장식의 슬롯 역산 (렌더 어댑터용). nil/미상이면 nil.
+    static func slotForItem(_ id: String?) -> DecorationSlot? {
+        guard let id else { return nil }
+        return allItems.first(where: { $0.id == id })?.slot
+    }
+
     /// 슬롯별 카탈로그 아이템 헬퍼.
     static func items(for slot: DecorationSlot) -> [ShopItem] {
         switch slot {

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopDetailView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopDetailView.swift
@@ -294,8 +294,8 @@ struct ShopDecoDetailView: View {
 
     private func content(slot: DecorationSlot) -> some View {
         let isOwned = store.state.isOwned(item.id)
-        // 적용 판정은 reducer 의 activeSlot 의존(equippedSlotId) 을 쓰지 않고 슬롯 직접 판정.
-        let isApplied = store.inventory?.equippedDecorations.id(for: slot) == item.id
+        // 전역 단일 착용 — 이 아이템이 현재 착용 id 와 같은지로 판정.
+        let isApplied = store.inventory?.equippedDecorationId == item.id
 
         return ZStack(alignment: .top) {
             // 라디얼 그라데이션 배경.
@@ -399,13 +399,11 @@ struct ShopDecoDetailView: View {
             if store.hearts < item.price {
                 onInsufficient()
             } else {
-                // reducer 의 구매/장착은 activeSlot 기준 → 해당 슬롯 선전송 후 구매.
-                store.send(.slotSelected(slot))
+                // 전역 단일 — 구매/장착이 activeSlot 에 의존하지 않으므로 itemId 만 전송.
                 store.send(.purchaseConfirmed(itemId: item.id))
                 onClose()
             }
         } else if !isApplied {
-            store.send(.slotSelected(slot))
             store.send(.decorationTapped(itemId: item.id))
             onClose()
         }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopFeature.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopFeature.swift
@@ -78,9 +78,9 @@ public struct ShopFeature {
                 .sorted { $0.sortOrder < $1.sortOrder }
         }
 
-        /// 현재 활성 슬롯에 장착된 장식 id.
-        public var equippedSlotId: String? {
-            inventory?.equippedDecorations.id(for: activeSlot)
+        /// 현재 장착 중인 장식 id (전역 단일).
+        public var equippedDecorationId: String? {
+            inventory?.equippedDecorationId
         }
 
         public var appliedBackgroundId: String? {
@@ -105,7 +105,7 @@ public struct ShopFeature {
         case slotSelected(DecorationSlot)
         /// 그리드 타일 탭 (꾸미기). nil 이면 "장식 없음"(해제).
         case decorationTapped(itemId: String?)
-        case equipResponse(Result<EquippedDecorations, AppError>)
+        case equipResponse(Result<String?, AppError>)
         case purchaseConfirmed(itemId: String)
         case purchaseResponse(Result<PurchaseResult, AppError>)
         /// 배경 타일 탭 — 보유면 적용, 미보유면 View 의 구매 확인을 거쳐 purchaseBackgroundConfirmed.
@@ -119,7 +119,7 @@ public struct ShopFeature {
         public enum Delegate: Equatable {
             case close
             case heartsChanged(Int)
-            case decorationsChanged(EquippedDecorations)
+            case decorationsChanged(String?)
             /// 가족 공유 배경이 적용됨 — MainTab 이 home.family 의 배경 id 를 갱신한다.
             case backgroundApplied(String?)
         }
@@ -134,8 +134,7 @@ public struct ShopFeature {
     /// 구매 성공 후 자동 장착까지 묶은 결과 (꾸미기).
     public struct PurchaseResult: Equatable, Sendable {
         public let heartsRemaining: Int
-        public let slot: DecorationSlot
-        public let equipped: EquippedDecorations
+        public let equippedDecorationId: String?
     }
 
     /// 배경 구매/적용 결과. heartsRemaining 이 nil 이면 구매 없이 적용만 한 경우.
@@ -191,15 +190,15 @@ public struct ShopFeature {
                 guard !state.isLoading else { return .none }
 
                 // "장식 없음" 또는 이미 장착된 아이템 재탭 → 해제.
-                if itemId == nil || itemId == state.equippedSlotId {
-                    return equip(&state, slot: state.activeSlot, itemId: nil)
+                if itemId == nil || itemId == state.equippedDecorationId {
+                    return equip(&state, itemId: nil)
                 }
 
                 guard let itemId else { return .none }
 
-                // 이미 보유 → 바로 장착.
+                // 이미 보유 → 바로 장착(전역 단일이라 기존 착용분은 서버가 덮어쓴다).
                 if state.isOwned(itemId) {
-                    return equip(&state, slot: state.activeSlot, itemId: itemId)
+                    return equip(&state, itemId: itemId)
                 }
 
                 // 미보유 → 가격 확인 후 구매 흐름.
@@ -221,14 +220,13 @@ public struct ShopFeature {
                 guard state.hearts >= item.price else { return .none }
                 state.isLoading = true
                 state.appError = nil
-                let slot = state.activeSlot
                 return .run { [shopRepository] send in
                     do {
-                        // 서버 권위 구매 → 잔액 수신, 이어서 해당 슬롯에 장착.
+                        // 서버 권위 구매 → 잔액 수신, 이어서 장착(서버 purchase 는 equip 안 함).
                         let heartsRemaining = try await shopRepository.purchase(itemId: itemId)
-                        let equipped = try await shopRepository.equipDecoration(slot: slot, itemId: itemId)
+                        let equippedId = try await shopRepository.equipDecoration(itemId: itemId)
                         await send(.purchaseResponse(.success(
-                            PurchaseResult(heartsRemaining: heartsRemaining, slot: slot, equipped: equipped)
+                            PurchaseResult(heartsRemaining: heartsRemaining, equippedDecorationId: equippedId)
                         )))
                     } catch {
                         await send(.purchaseResponse(.failure(AppError.from(error))))
@@ -240,16 +238,16 @@ public struct ShopFeature {
                 state.isLoading = false
                 state.hearts = result.heartsRemaining
                 if var inv = state.inventory {
-                    inv.equippedDecorations = result.equipped
-                    // 구매한 아이템을 보유 목록에 반영 (장착된 슬롯 id 기준).
-                    if let equippedId = result.equipped.id(for: result.slot) {
+                    inv.equippedDecorationId = result.equippedDecorationId
+                    // 구매한 아이템을 보유 목록에 반영.
+                    if let equippedId = result.equippedDecorationId {
                         inv.ownedDecorationIds.insert(equippedId)
                     }
                     state.inventory = inv
                 }
                 return .merge(
                     .send(.delegate(.heartsChanged(result.heartsRemaining))),
-                    .send(.delegate(.decorationsChanged(result.equipped)))
+                    .send(.delegate(.decorationsChanged(result.equippedDecorationId)))
                 )
 
             case .purchaseResponse(.failure(let error)):
@@ -257,13 +255,13 @@ public struct ShopFeature {
                 state.appError = error
                 return .none
 
-            case .equipResponse(.success(let equipped)):
+            case .equipResponse(.success(let equippedId)):
                 state.isLoading = false
                 if var inv = state.inventory {
-                    inv.equippedDecorations = equipped
+                    inv.equippedDecorationId = equippedId
                     state.inventory = inv
                 }
-                return .send(.delegate(.decorationsChanged(equipped)))
+                return .send(.delegate(.decorationsChanged(equippedId)))
 
             case .equipResponse(.failure(let error)):
                 state.isLoading = false
@@ -324,14 +322,14 @@ public struct ShopFeature {
         }
     }
 
-    /// 슬롯 장착/해제 effect 생성 (중복 제거용).
-    private func equip(_ state: inout State, slot: DecorationSlot, itemId: String?) -> Effect<Action> {
+    /// 장착/해제 effect 생성 (중복 제거용). 전역 단일 — itemId nil 이면 해제.
+    private func equip(_ state: inout State, itemId: String?) -> Effect<Action> {
         state.isLoading = true
         state.appError = nil
         return .run { [shopRepository] send in
             do {
-                let equipped = try await shopRepository.equipDecoration(slot: slot, itemId: itemId)
-                await send(.equipResponse(.success(equipped)))
+                let equippedId = try await shopRepository.equipDecoration(itemId: itemId)
+                await send(.equipResponse(.success(equippedId)))
             } catch {
                 await send(.equipResponse(.failure(AppError.from(error))))
             }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopView.swift
@@ -195,21 +195,19 @@ struct ShopView: View {
         }
     }
 
-    // 미리보기 캐릭터 — 3슬롯 장착 동시 반영 + 탭한 장식(활성 슬롯)을 구매 전 미리 얹어 보여준다.
+    // 미리보기 캐릭터 — 전역 단일 착용 1개를 그 장식의 슬롯 자리에 반영.
+    // 탭한 장식(decoPreviewId)이 있으면 구매 전에도 미리 얹어 보여준다.
     private var preview: some View {
-        let equipped = store.inventory?.equippedDecorations ?? EquippedDecorations()
-        // 활성 슬롯은 미리보기(decoPreviewId)가 있으면 우선, 없으면 장착값.
-        let head = store.activeSlot == .head ? (decoPreviewId ?? equipped.head) : equipped.head
-        let back = store.activeSlot == .back ? (decoPreviewId ?? equipped.back) : equipped.back
-        let feet = store.activeSlot == .feet ? (decoPreviewId ?? equipped.feet) : equipped.feet
+        let shownId = decoPreviewId ?? store.equippedDecorationId
+        let slot = DecorationCatalog.slotForItem(shownId)
         return V2Mongle(
             color: V2Palette.alex,
             size: 96,
             hideName: true,
-            backDecorationId: back,
-            feetDecorationId: feet
+            backDecorationId: slot == .back ? shownId : nil,
+            feetDecorationId: slot == .feet ? shownId : nil
         ) {
-            DecorationCatalog.headView(for: head)
+            DecorationCatalog.headView(for: slot == .head ? shownId : nil)
         }
         // 머리/등/발밑 세그먼트 바로 아래라 살짝 답답하지 않도록 캐릭터를 카드 안에서 조금 내린다.
         .offset(y: 14)
@@ -238,7 +236,7 @@ struct ShopView: View {
                 decoPreviewId = nil
                 store.send(.decorationTapped(itemId: nil))
             } label: {
-                V2DecoTile(name: L10n.tr("shop_deco_none"), equipped: store.equippedSlotId == nil) {
+                V2DecoTile(name: L10n.tr("shop_deco_none"), equipped: store.equippedDecorationId == nil) {
                     Circle().strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [4]))
                         .foregroundStyle(V2Palette.muted).frame(width: 40, height: 40)
                 }
@@ -247,7 +245,7 @@ struct ShopView: View {
 
             ForEach(store.slotDecorations) { item in
                 let owned = store.state.isOwned(item.id)
-                let equipped = store.equippedSlotId == item.id
+                let equipped = store.equippedDecorationId == item.id
                 Button { onDecoTileTapped(item) } label: {
                     V2DecoTile(
                         name: item.name,
@@ -383,7 +381,7 @@ struct ShopView: View {
                 catalog: DecorationCatalog.allItems + BackgroundCatalog.items,
                 inventory: ShopInventory(
                     ownedDecorationIds: [DecorationCatalog.flowerCrown],
-                    equippedDecorations: EquippedDecorations(head: DecorationCatalog.flowerCrown)
+                    equippedDecorationId: DecorationCatalog.flowerCrown
                 )
             )
         ) {
@@ -420,19 +418,11 @@ private struct PreviewShopRepository: ShopRepositoryInterface {
     func getInventory() async throws -> ShopInventory {
         ShopInventory(
             ownedDecorationIds: [DecorationCatalog.flowerCrown],
-            equippedDecorations: EquippedDecorations(head: DecorationCatalog.flowerCrown)
+            equippedDecorationId: DecorationCatalog.flowerCrown
         )
     }
     func purchase(itemId: String) async throws -> Int { 80 }
-    func equipDecoration(slot: DecorationSlot, itemId: String?) async throws -> EquippedDecorations {
-        var eq = EquippedDecorations()
-        switch slot {
-        case .head: eq.head = itemId
-        case .back: eq.back = itemId
-        case .feet: eq.feet = itemId
-        }
-        return eq
-    }
+    func equipDecoration(itemId: String?) async throws -> String? { itemId }
     func applyBackground(itemId: String) async throws -> ShopInventory {
         ShopInventory(ownedBackgroundIds: [itemId], appliedBackgroundId: itemId)
     }

--- a/MongleFeatures/Tests/MongleFeaturesTests/ShopFeatureTests.swift
+++ b/MongleFeatures/Tests/MongleFeaturesTests/ShopFeatureTests.swift
@@ -20,7 +20,7 @@ final class ShopFeatureTests: XCTestCase {
         let catalog = [item(flower, price: 35), item(star, price: 40)]
         let inventory = ShopInventory(
             ownedDecorationIds: [flower],
-            equippedDecorations: EquippedDecorations(head: flower)
+            equippedDecorationId: flower
         )
         repo.catalogResult = catalog
         repo.inventoryResult = inventory
@@ -71,15 +71,14 @@ final class ShopFeatureTests: XCTestCase {
             $0.shopRepository = repo
         }
 
-        let equipped = EquippedDecorations(head: flower)
         await store.send(.decorationTapped(itemId: flower)) {
             $0.isLoading = true
         }
-        await store.receive(.equipResponse(.success(equipped))) {
+        await store.receive(.equipResponse(.success(flower))) {
             $0.isLoading = false
-            $0.inventory?.equippedDecorations = equipped
+            $0.inventory?.equippedDecorationId = self.flower
         }
-        await store.receive(.delegate(.decorationsChanged(equipped)))
+        await store.receive(.delegate(.decorationsChanged(flower)))
     }
 
     // MARK: - decorationTapped: 미소유 + 하트 충분 → purchase → heartsChanged
@@ -104,15 +103,14 @@ final class ShopFeatureTests: XCTestCase {
         await store.receive(.purchaseConfirmed(itemId: flower)) {
             $0.isLoading = true
         }
-        let equipped = EquippedDecorations(head: flower)
-        await store.receive(.purchaseResponse(.success(.init(heartsRemaining: 15, slot: .head, equipped: equipped)))) {
+        await store.receive(.purchaseResponse(.success(.init(heartsRemaining: 15, equippedDecorationId: flower)))) {
             $0.isLoading = false
             $0.hearts = 15
-            $0.inventory?.equippedDecorations = equipped
+            $0.inventory?.equippedDecorationId = self.flower
             $0.inventory?.ownedDecorationIds = [self.flower]
         }
         await store.receive(.delegate(.heartsChanged(15)))
-        await store.receive(.delegate(.decorationsChanged(equipped)))
+        await store.receive(.delegate(.decorationsChanged(flower)))
     }
 
     // MARK: - decorationTapped: 미소유 + 하트 부족 → no-op (View 가 안내 팝업만, 충전 흐름 제거됨)
@@ -177,7 +175,7 @@ final class ShopFeatureTests: XCTestCase {
                 catalog: [item(flower, price: 35)],
                 inventory: ShopInventory(
                     ownedDecorationIds: [flower],
-                    equippedDecorations: EquippedDecorations(head: flower)
+                    equippedDecorationId: flower
                 )
             )
         ) {
@@ -186,14 +184,14 @@ final class ShopFeatureTests: XCTestCase {
             $0.shopRepository = repo
         }
 
-        let unequipped = EquippedDecorations(head: nil)
+        // 장착중 재탭 → 해제(itemId nil). Mock 은 요청 itemId(nil) 를 그대로 반환.
         await store.send(.decorationTapped(itemId: flower)) {
             $0.isLoading = true
         }
-        await store.receive(.equipResponse(.success(unequipped))) {
+        await store.receive(.equipResponse(.success(nil))) {
             $0.isLoading = false
-            $0.inventory?.equippedDecorations = unequipped
+            $0.inventory?.equippedDecorationId = nil
         }
-        await store.receive(.delegate(.decorationsChanged(unequipped)))
+        await store.receive(.delegate(.decorationsChanged(nil)))
     }
 }

--- a/MongleFeatures/Tests/MongleFeaturesTests/TestHelpers.swift
+++ b/MongleFeatures/Tests/MongleFeaturesTests/TestHelpers.swift
@@ -49,8 +49,8 @@ final class MockShopRepository: ShopRepositoryInterface, @unchecked Sendable {
     /// purchase 후 반환할 잔여 하트.
     var purchaseHeartsRemaining: Int = 0
     var purchaseError: Error?
-    /// equipDecoration 이 반환할 장착 현황. nil 이면 (slot,itemId) 로 즉석 구성.
-    var equipResult: EquippedDecorations?
+    /// equipDecoration 이 반환할 장착 id. nil 이면 요청 itemId 를 그대로 반환.
+    var equipResult: String?
     var equipError: Error?
 
     func getCatalog() async throws -> [ShopItem] {
@@ -68,16 +68,10 @@ final class MockShopRepository: ShopRepositoryInterface, @unchecked Sendable {
         return purchaseHeartsRemaining
     }
 
-    func equipDecoration(slot: DecorationSlot, itemId: String?) async throws -> EquippedDecorations {
+    func equipDecoration(itemId: String?) async throws -> String? {
         if let equipError { throw equipError }
         if let equipResult { return equipResult }
-        var eq = EquippedDecorations()
-        switch slot {
-        case .head: eq.head = itemId
-        case .back: eq.back = itemId
-        case .feet: eq.feet = itemId
-        }
-        return eq
+        return itemId
     }
 
     /// applyBackground 가 반환할 인벤토리. nil 이면 inventoryResult 에 itemId 를 적용해 반환.


### PR DESCRIPTION
## 변경 (단순 컷오버 — 하위호환 없음, 서버 동시 배포 전제)
장식 착용을 **슬롯별 1개 → 전체 1개(global single)** 로 전환.

- `EquippedDecorations{head/back/feet}`·`id(for:)` 제거 → `ShopInventory.equippedDecorationId: String?` 단일
- equip API 호출 body `{itemId}`(slot 제거), equipDecoration(itemId:) 단일 시그니처
- `ShopFeature`: 같은 id 재탭→해제, 다른 id→교체. `equippedSlotId`→전역 `equippedDecorationId`
- 렌더: V2Mongle head/back/feet 파라미터 구조 유지하되, 착용 id 1개를 `DecorationCatalog.slotForItem(id)` 로 slot 역산해 해당 자리에만 주입 (앵커 위치·placement·hand 슬롯은 2단계)
- 슬롯 세그먼트(머리/등/발밑)는 브라우징용으로 유지

## 검증
`xcodebuild build` SUCCEEDED · ShopFeatureTests 7/7

## ⚠️ 서버 PR(rrheon/Mongle-Server feat/deco-single-equip)과 동시 배포 필수
🤖 Generated with [Claude Code](https://claude.com/claude-code)