### PR TITLE
fix: '장식 없음' 셀 크기 깨짐 수정 + 제거 확인 팝업

### DIFF
--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopView.swift
@@ -19,6 +19,8 @@ struct ShopView: View {
     @State private var previewItem: ShopItem?
     /// 하트 부족 안내 팝업 표시 여부 (충전 버튼 없음).
     @State private var showInsufficient = false
+    /// '장식 없음' 탭 시 뜨는 장식 제거 확인 팝업 표시 여부.
+    @State private var showRemoveConfirm = false
     /// 꾸미기 미리보기 — 탭한 장식을 (구매 전에도) 활성 슬롯에 미리 얹어 캐릭터에 보여준다.
     /// 슬롯 전환 시 해제. nil 이면 장착 상태 그대로 표시.
     @State private var decoPreviewId: String?
@@ -50,6 +52,7 @@ struct ShopView: View {
             onDismiss: { store.send(.dismissError) }
         )
         .overlay { insufficientPopup }
+        .overlay { removeConfirmPopup }
         // 타일 탭 → 즉시 팝업 대신 미리보기(상세) 화면으로 push (부모 MainTab NavigationStack 에 얹는다).
         // fullScreenCover 모달 대신 네이티브 슬라이드 전환. 닫기/구매/적용은 상세 하단 액션바에서.
         .navigationDestination(item: $previewItem) { item in
@@ -231,10 +234,12 @@ struct ShopView: View {
 
     private var decoGrid: some View {
         LazyVGrid(columns: decoCols, spacing: 10) {
-            // "장식 없음" 타일 — 해제용.
+            // "장식 없음" 타일 — 해제용. 착용 중인 장식이 있을 때만 제거 확인 팝업을 띄운다
+            // (이미 아무것도 안 낀 상태면 탭해도 할 일이 없으므로 팝업을 띄우지 않는다).
             Button {
-                decoPreviewId = nil
-                store.send(.decorationTapped(itemId: nil))
+                if store.equippedDecorationId != nil {
+                    showRemoveConfirm = true
+                }
             } label: {
                 V2DecoTile(name: L10n.tr("shop_deco_none"), equipped: store.equippedDecorationId == nil) {
                     Circle().strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [4]))
@@ -366,6 +371,32 @@ struct ShopView: View {
                 secondaryLabel: nil,
                 onPrimary: { showInsufficient = false },
                 onSecondary: nil
+            )
+            .transition(.identity)
+        }
+    }
+
+    // 장식 제거 확인 — '장식 없음' 타일을 탭하면 띄운다. 확인 시 착용 장식을 해제한다.
+    @ViewBuilder
+    private var removeConfirmPopup: some View {
+        if showRemoveConfirm {
+            MonglePopupView(
+                icon: .init(
+                    systemName: "sparkles",
+                    foregroundColor: V2Palette.mint,
+                    backgroundColor: V2Palette.mint.opacity(0.16)
+                ),
+                title: L10n.tr("shop_remove_deco_title"),
+                description: L10n.tr("shop_remove_deco_desc"),
+                primaryLabel: L10n.tr("common_confirm"),
+                secondaryLabel: L10n.tr("common_cancel"),
+                isDestructive: true,
+                onPrimary: {
+                    decoPreviewId = nil
+                    store.send(.decorationTapped(itemId: nil))
+                    showRemoveConfirm = false
+                },
+                onSecondary: { showRemoveConfirm = false }
             )
             .transition(.identity)
         }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/V2/V2ShopScreens.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/V2/V2ShopScreens.swift
@@ -222,7 +222,10 @@ struct V2DecoTile<Preview: View>: View {
             Text(name).font(V2Font.suit(12, .bold)).foregroundStyle(V2Palette.ink)
                 .lineLimit(1).minimumScaleFactor(0.8)
                 .frame(height: 16)
-            statusLabel.frame(height: 20)
+            // 상태 슬롯은 콘텐츠 유무와 무관하게 항상 동일한 폭·높이를 차지해야 한다.
+            // (이전엔 '장식 없음' 타일이 '장착중' 배지를 잃으면 상태 뷰가 nil → 폭 0 으로
+            //  접혀 VStack 의 이상폭이 달라지고, aspectRatio(.fit) 가 셀 크기를 다르게 계산했다.)
+            statusLabel.frame(maxWidth: .infinity, minHeight: 20, maxHeight: 20)
         }
         .padding(12)
         .frame(maxWidth: .infinity).aspectRatio(1 / 1.05, contentMode: .fit)
@@ -249,6 +252,9 @@ struct V2DecoTile<Preview: View>: View {
                 Image(systemName: "heart.fill").font(.system(size: 12)).foregroundStyle(V2Palette.heartPink)
                 Text(price).font(V2Font.suit(11, .heavy)).foregroundStyle(V2Palette.ink)
             }
+        } else {
+            // 표시할 상태가 없어도 빈 슬롯을 명시적으로 채워 셀 레이아웃을 흔들지 않는다.
+            Color.clear
         }
     }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -25,6 +25,8 @@
 "shop_apply_title" = "Apply this?";
 "shop_apply_desc" = "Apply '%@'.";
 "shop_apply_confirm" = "Apply";
+"shop_remove_deco_title" = "Remove decoration?";
+"shop_remove_deco_desc" = "Take off the equipped decoration and return to the default look.";
 "shop_insufficient_title" = "Not enough hearts";
 "shop_insufficient_desc" = "Not enough hearts. Answer questions to collect more.";
 "shop_insufficient_confirm" = "Get hearts";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -25,6 +25,8 @@
 "shop_apply_title" = "適用しますか？";
 "shop_apply_desc" = "'%@'を適用します。";
 "shop_apply_confirm" = "適用する";
+"shop_remove_deco_title" = "飾りを外しますか？";
+"shop_remove_deco_desc" = "着けている飾りを外して、もとの姿に戻します。";
 "shop_insufficient_title" = "ハートが足りません";
 "shop_insufficient_desc" = "ハートが足りません。回答するとハートを集められます。";
 "shop_insufficient_confirm" = "ハートを補充";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -25,6 +25,8 @@
 "shop_apply_title" = "적용할까요?";
 "shop_apply_desc" = "'%@'을(를) 적용합니다.";
 "shop_apply_confirm" = "적용하기";
+"shop_remove_deco_title" = "장식을 제거할까요?";
+"shop_remove_deco_desc" = "착용 중인 장식을 벗고 기본 모습으로 돌아갑니다.";
 "shop_insufficient_title" = "하트가 부족해요";
 "shop_insufficient_desc" = "하트가 부족해요. 답변을 남기면 하트를 모을 수 있어요.";
 "shop_insufficient_confirm" = "하트 채우기";


### PR DESCRIPTION
## 배경
상점 꾸미기 그리드에서 두 가지를 처리했다.

1. **'장식 없음' 셀 크기 깨짐 버그** — 다른 장식을 착용해 '장식 없음' 타일의 `equipped`가 false가 되면(=`장착중` 배지가 사라지면) 그 셀만 다른 셀과 크기가 어긋났다.
2. **제거 확인 팝업 요청** — '장식 없음'을 탭하면 곧장 해제되던 동작을, "장식을 제거할까요?" 확인 팝업을 거치도록 변경.

## 변경 내용
### 1. 셀 크기 버그 (`V2ShopScreens.swift`)
- 원인: `V2DecoTile`의 상태 라벨이 장착중/보유중/가격 어디에도 해당하지 않으면 `@ViewBuilder`가 `nil`을 반환 → 상태 슬롯 폭이 0으로 접혀 VStack 이상폭이 달라지고 `aspectRatio(.fit)`가 셀 크기를 다르게 계산.
- 수정: 빈 상태에 `else { Color.clear }` 플레이스홀더 추가 + 상태 슬롯을 `frame(maxWidth: .infinity, minHeight: 20, maxHeight: 20)`로 고정 → 콘텐츠와 무관하게 항상 동일 폭·높이 확보.

### 2. 제거 확인 팝업 (`ShopView.swift`)
- '장식 없음' 타일 탭 → 착용 중인 장식이 있을 때만 `MonglePopupView`(destructive)로 확인 팝업 표시.
- **확인** → 해제(`decorationTapped(itemId: nil)`), **취소** → 닫기. 미착용 상태면 팝업 미표시.
- L10n 키 `shop_remove_deco_title` / `shop_remove_deco_desc` ko/en/ja 추가.

## 검증
- iOS 시뮬레이터(iPhone 17 Pro) **BUILD SUCCEEDED**.
- ImageRenderer 스냅샷으로 (없음/장착중/가격) 세 상태 타일을 같은 그리드에 렌더 → 세 셀 모두 동일 크기·정렬 육안 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)