### PR TITLE
feat: 장식 placement 세밀화 + 손(hand) 슬롯

### DIFF
--- a/Domain/Sources/Domain/Entities/Shop.swift
+++ b/Domain/Sources/Domain/Entities/Shop.swift
@@ -15,9 +15,11 @@ public enum ShopItemKind: String, Sendable, Equatable {
     case decoration
 }
 
-/// 장식이 얹히는 캐릭터 슬롯. MVP 에서는 head 만 활성, back/feet 는 노출만 하고 비활성.
+/// 장식이 얹히는 캐릭터 슬롯(브라우징/분류용). 착용은 전역 단일 1개라 슬롯은 카탈로그 분류에만 쓰인다.
+/// 선언 순서 = 세그먼트 노출 순서(머리·손·등·발밑). allCases 가 선언순을 따른다.
 public enum DecorationSlot: String, Sendable, Equatable, CaseIterable {
     case head
+    case hand
     case back
     case feet
 }

--- a/MongleData/Sources/MongleData/Mappers/ShopMapper.swift
+++ b/MongleData/Sources/MongleData/Mappers/ShopMapper.swift
@@ -42,6 +42,7 @@ struct ShopMapper {
         guard let raw else { return nil }
         switch raw.lowercased() {
         case "head": return .head
+        case "hand": return .hand
         case "back": return .back
         case "feet": return .feet
         default:     return nil

--- a/MongleFeatures/Sources/MongleFeatures/Design/Components.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Design/Components.swift
@@ -788,7 +788,10 @@ public struct MongleView: View {
         let container: CGFloat = bodySize + 14   // 70 (본인 ring 포함 본체 footprint)
         // 장착 시에만 위/아래 여유를 둔다(미장착=컴팩트). 머리 장식이 상단 "답변" 배지와
         // 겹치지 않도록 headRoom 만큼 본체를 아래로 내려 배지와 분리한다.
-        let headRoom: CGFloat = headDecorationId != nil ? 24 : 0
+        // aboveHead(후광)는 머리 위로 더 띄우므로 여유를 더 준다. hand(풍선)는 좌우로 나가지만
+        // 위쪽 여유는 head 와 비슷하게.
+        let headAnchor: DecorationAnchor? = headDecorationId.map { DecorationCatalog.placement(for: $0).anchor }
+        let headRoom: CGFloat = headDecorationId == nil ? 0 : (headAnchor == .aboveHead ? 34 : 24)
         let feetRoom: CGFloat = feetDecorationId != nil ? 14 : 0
         return ZStack {
             // 등(back) 장식 — 본체 뒤에 먼저 그려 zIndex 가 본체보다 뒤. 본체보다 크게 그려
@@ -810,17 +813,31 @@ public struct MongleView: View {
                     .offset(y: bodySize * 0.5)
                     .allowsHitTesting(false)
             }
-            // 머리(head) 장식 — 머리 위에 얹되 본체 상단과 살짝 겹치게(머리에 쓴 모양).
+            // 머리계열(head/aboveHead/hand) 장식 — placement.anchor 로 위치 분기.
             // 같은 ZStack 이라 걷기/hop 시 함께 이동. id→뷰는 DecorationCatalog(headView) 공유.
             if let headDecorationId {
+                let placement = DecorationCatalog.placement(for: headDecorationId)
+                let base = homeHeadBaseline(placement.anchor, bodySize: bodySize)
                 DecorationCatalog.headView(for: headDecorationId)
-                    .offset(y: -bodySize * 0.5)
+                    .scaleEffect(placement.scale)
+                    .offset(x: base.width + placement.offset.width * bodySize,
+                            y: base.height + placement.offset.height * bodySize)
                     .allowsHitTesting(false)
             }
         }
         .frame(width: container, height: container)
         .padding(.top, headRoom)
         .padding(.bottom, feetRoom)
+    }
+
+    /// 앵커별 head 계열 baseline 오프셋 (home 좌표 기준, bodySize 비례).
+    private func homeHeadBaseline(_ anchor: DecorationAnchor, bodySize: CGFloat) -> CGSize {
+        switch anchor {
+        case .onHead:    return CGSize(width: 0, height: -bodySize * 0.5)    // 현행
+        case .aboveHead: return CGSize(width: 0, height: -bodySize * 0.62)   // 머리 위로 살짝 띄움(onHead -0.5 대비)
+        case .hand:      return CGSize(width: bodySize * 0.42, height: bodySize * 0.12) // 측면·하단 손
+        case .back, .feet: return CGSize(width: 0, height: -bodySize * 0.5)  // 안전 기본
+        }
     }
 
     @ViewBuilder

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/MainTab/MainTabView.swift
@@ -192,7 +192,8 @@ struct MainTabView: View {
                 let isCurrentUser = user.id == currentUserId
                 let moodId = isCurrentUser ? (store.previewMoodId ?? store.currentUserMoodId ?? user.moodId) : user.moodId
                 let eqId = isCurrentUser ? store.home.currentUser?.equippedDecorationId : nil
-                let eqSlot = DecorationCatalog.slotForItem(eqId)
+                // 부착 위치(anchor) 로 3필드 분기: onHead/aboveHead/hand→head, back→back, feet→feet.
+                let eqAnchor: DecorationAnchor? = eqId.map { DecorationCatalog.placement(for: $0).anchor }
                 return MongleMember(
                     id: user.id,
                     name: user.name,
@@ -202,9 +203,9 @@ struct MainTabView: View {
                     hasSkipped: store.home.memberSkippedStatus[user.id] ?? false,
                     // 본인 멤버만 전역 단일 착용 1개를 그 장식의 슬롯 자리에 주입 (타인 동기화는 후속).
                     // 상점 장착 시 decorationsChanged delegate 가 currentUser 를 갱신해 즉시 반영된다.
-                    headDecorationId: eqSlot == .head ? eqId : nil,
-                    backDecorationId: eqSlot == .back ? eqId : nil,
-                    feetDecorationId: eqSlot == .feet ? eqId : nil
+                    headDecorationId: (eqAnchor == .back || eqAnchor == .feet) ? nil : eqId,
+                    backDecorationId: eqAnchor == .back ? eqId : nil,
+                    feetDecorationId: eqAnchor == .feet ? eqId : nil
                 )
             }
         return HomeViewV2(

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/DecorationCatalog.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/DecorationCatalog.swift
@@ -6,23 +6,46 @@
 //  모두 이 매핑을 공유한다 (단일 진실). 카탈로그 기본값(디자인 값)도 여기서 제공해
 //  서버 미구현 동안 Mock/프리뷰가 동일한 데이터로 동작하도록 한다.
 //
-//  슬롯별 카탈로그 id ↔ 디자인 뷰:
+//  슬롯별 카탈로그 id ↔ 디자인 뷰 (유료 전부 price 50):
 //    [머리 head]
-//    deco_flower_crown  들꽃 화관  35  V2FlowerCrown
-//    deco_star_halo     별 후광    40  V2StarHalo
-//    deco_satin_ribbon  새틴 리본  25  V2SatinRibbon
-//    deco_balloon_bunch 풍선 다발  50  V2BalloonBunch
-//    deco_santa_hat     산타 모자  60  V2SantaHat (시즌)
+//    deco_flower_crown  들꽃 화관  V2FlowerCrown
+//    deco_star_halo     별 후광    V2StarHalo (anchor=.aboveHead)
+//    deco_satin_ribbon  새틴 리본  V2SatinRibbon
+//    deco_santa_hat     산타 모자  V2SantaHat (시즌)
+//    [손 hand]
+//    deco_balloon_bunch 풍선 다발  V2BalloonBunch (anchor=.hand)
 //    [등 back]
-//    deco_angel_wings   천사 날개  45  V2AngelWings (PNG)
-//    deco_cape          망토       40  V2Cape
+//    deco_angel_wings   천사 날개  V2AngelWings (PNG)
+//    deco_cape          망토       V2Cape
 //    [발밑 feet]
-//    deco_sneakers      운동화     30  V2Sneakers
-//    deco_cloud_pad     구름 받침  35  V2CloudPad
+//    deco_sneakers      운동화     V2Sneakers
+//    deco_cloud_pad     구름 받침  V2CloudPad
 //
 
 import SwiftUI
 import Domain
+
+// MARK: - 부착 위치(placement) 모델
+
+/// 장식이 캐릭터의 어디에 붙는지(렌더 좌표 기준점). 슬롯(enum)과 별개로
+/// 렌더 레이어가 위치를 분기하는 단일 소스다. slot=head 라도 anchor=.hand 처럼
+/// 슬롯과 부착위치가 갈릴 수 있다(예: 풍선 다발은 head 슬롯이지만 손에 든다).
+enum DecorationAnchor {
+    case onHead     // 머리에 씀 (화관·리본·모자)
+    case aboveHead  // 머리 위로 더 띄움 (후광)
+    case hand       // 손(측면·하단)에 듦 (풍선)
+    case back       // 등 (날개·망토)
+    case feet       // 발밑 (운동화·구름)
+}
+
+/// 부착 위치 + 추가 nudge 오프셋 + 스케일.
+/// `offset` 은 bodySize 비례 단위로 해석한다 — 실제 적용 = offset.width*bodySize, offset.height*bodySize.
+/// 레이어별 앵커 baseline 에 이 offset 을 더해 최종 위치를 정한다.
+struct DecorationPlacement {
+    var anchor: DecorationAnchor
+    var offset: CGSize = .zero
+    var scale: CGFloat = 1.0
+}
 
 enum DecorationCatalog {
 
@@ -52,10 +75,14 @@ enum DecorationCatalog {
                  price: 50, assetName: starHalo, slot: .head, sortOrder: 2),
         ShopItem(id: satinRibbon, kind: .decoration, name: L10n.tr("shop_item_satin_ribbon"),
                  price: 50, assetName: satinRibbon, slot: .head, sortOrder: 3),
-        ShopItem(id: balloonBunch, kind: .decoration, name: L10n.tr("shop_item_balloon_bunch"),
-                 price: 50, assetName: balloonBunch, slot: .head, sortOrder: 4),
         ShopItem(id: santaHat, kind: .decoration, name: L10n.tr("shop_item_santa_hat"),
                  price: 50, assetName: santaHat, slot: .head, isSeasonal: true, sortOrder: 5)
+    ]
+
+    /// 손(hand) 슬롯 장식 카탈로그. 풍선 다발은 손에 들고 다닌다(anchor=.hand).
+    static let handItems: [ShopItem] = [
+        ShopItem(id: balloonBunch, kind: .decoration, name: L10n.tr("shop_item_balloon_bunch"),
+                 price: 50, assetName: balloonBunch, slot: .hand, sortOrder: 1)
     ]
 
     /// 등(back) 슬롯 장식 카탈로그.
@@ -75,7 +102,7 @@ enum DecorationCatalog {
     ]
 
     /// 전체 장식 카탈로그 (모든 슬롯 합본 — 서버 미구현 동안 Mock/프리뷰 기본값).
-    static let allItems: [ShopItem] = headItems + backItems + feetItems
+    static let allItems: [ShopItem] = headItems + handItems + backItems + feetItems
 
     // MARK: - id → 뷰 (슬롯 무관 매핑)
 
@@ -134,6 +161,28 @@ enum DecorationCatalog {
         }
     }
 
+    // MARK: - id → 부착 위치(placement)
+
+    /// 장식 id → 부착 위치. anchor 분류의 단일 소스. 두 렌더 레이어가 모두 이걸 참조한다.
+    /// offset 은 bodySize 비례 nudge(레이어 baseline 에 가산), scale 은 배율.
+    static func placement(for id: String?) -> DecorationPlacement {
+        switch id {
+        case flowerCrown, satinRibbon, santaHat:
+            return DecorationPlacement(anchor: .onHead, offset: .zero, scale: 1.0)
+        case starHalo:
+            return DecorationPlacement(anchor: .aboveHead, offset: .zero, scale: 1.0)
+        case balloonBunch:
+            return DecorationPlacement(anchor: .hand, offset: .zero, scale: 1.0)
+        case angelWings, cape:
+            return DecorationPlacement(anchor: .back, offset: .zero, scale: 1.0)
+        case sneakers, cloudPad:
+            return DecorationPlacement(anchor: .feet, offset: .zero, scale: 1.0)
+        default:
+            // 미상/nil — 무해 기본 (머리에 씀).
+            return DecorationPlacement(anchor: .onHead, offset: .zero, scale: 1.0)
+        }
+    }
+
     /// 단일 장착 id → 그 장식의 슬롯 역산 (렌더 어댑터용). nil/미상이면 nil.
     static func slotForItem(_ id: String?) -> DecorationSlot? {
         guard let id else { return nil }
@@ -144,6 +193,7 @@ enum DecorationCatalog {
     static func items(for slot: DecorationSlot) -> [ShopItem] {
         switch slot {
         case .head: return headItems
+        case .hand: return handItems
         case .back: return backItems
         case .feet: return feetItems
         }

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopDetailView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopDetailView.swift
@@ -23,6 +23,7 @@ import Domain
 func shopSlotTitle(_ slot: DecorationSlot) -> String {
     switch slot {
     case .head: return L10n.tr("shop_slot_head")
+    case .hand: return L10n.tr("shop_slot_hand")
     case .back: return L10n.tr("shop_slot_back")
     case .feet: return L10n.tr("shop_slot_feet")
     }
@@ -30,22 +31,25 @@ func shopSlotTitle(_ slot: DecorationSlot) -> String {
 
 // MARK: - 슬롯별 장식 착용 몽글 빌더
 
-/// V2Mongle 의 슬롯별 init 분기를 한 곳으로 모은다.
-/// - head: 제네릭 trailing closure(decoration:) 로 head 뷰를 얹는다.
-/// - back/feet: EmptyView convenience init 의 backDecorationId/feetDecorationId 파라미터.
+/// V2Mongle 의 부착위치별 init 분기를 한 곳으로 모은다.
+/// 슬롯(enum)이 아니라 placement.anchor 로 분기한다 — 같은 head 슬롯이라도
+/// 후광(aboveHead)·풍선(hand)은 머리계열(headDecorationId) 경로로 렌더된다.
+/// - back/feet: backDecorationId/feetDecorationId 파라미터.
+/// - 그 외(onHead/aboveHead/hand): headDecorationId 파라미터(placement 기반 위치).
+/// slot 파라미터는 호출부 시그니처 호환을 위해 유지하되 분기에는 쓰지 않는다.
 @ViewBuilder
 func decoratedMongle(slot: DecorationSlot, itemId: String, size: CGFloat, eyeSize: CGFloat) -> some View {
-    switch slot {
-    case .head:
-        V2Mongle(color: V2Palette.alex, size: size, eyeSize: eyeSize, hideName: true) {
-            DecorationCatalog.headView(for: itemId)
-        }
+    let anchor = DecorationCatalog.placement(for: itemId).anchor
+    switch anchor {
     case .back:
         V2Mongle(color: V2Palette.alex, size: size, eyeSize: eyeSize, hideName: true,
                  backDecorationId: itemId)
     case .feet:
         V2Mongle(color: V2Palette.alex, size: size, eyeSize: eyeSize, hideName: true,
                  feetDecorationId: itemId)
+    case .onHead, .aboveHead, .hand:
+        V2Mongle(color: V2Palette.alex, size: size, eyeSize: eyeSize, hideName: true,
+                 headDecorationId: itemId)
     }
 }
 

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopView.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/Shop/ShopView.swift
@@ -193,6 +193,7 @@ struct ShopView: View {
     private func slotTitle(_ slot: DecorationSlot) -> String {
         switch slot {
         case .head: return L10n.tr("shop_slot_head")
+        case .hand: return L10n.tr("shop_slot_hand")
         case .back: return L10n.tr("shop_slot_back")
         case .feet: return L10n.tr("shop_slot_feet")
         }
@@ -202,16 +203,16 @@ struct ShopView: View {
     // 탭한 장식(decoPreviewId)이 있으면 구매 전에도 미리 얹어 보여준다.
     private var preview: some View {
         let shownId = decoPreviewId ?? store.equippedDecorationId
-        let slot = DecorationCatalog.slotForItem(shownId)
+        // 부착 위치(anchor) 로 분기: back→back, feet→feet, 그 외(onHead/aboveHead/hand)→head.
+        let anchor = DecorationCatalog.placement(for: shownId).anchor
         return V2Mongle(
             color: V2Palette.alex,
             size: 96,
             hideName: true,
-            backDecorationId: slot == .back ? shownId : nil,
-            feetDecorationId: slot == .feet ? shownId : nil
-        ) {
-            DecorationCatalog.headView(for: slot == .head ? shownId : nil)
-        }
+            backDecorationId: anchor == .back ? shownId : nil,
+            feetDecorationId: anchor == .feet ? shownId : nil,
+            headDecorationId: (anchor == .back || anchor == .feet) ? nil : shownId
+        )
         // 머리/등/발밑 세그먼트 바로 아래라 살짝 답답하지 않도록 캐릭터를 카드 안에서 조금 내린다.
         .offset(y: 14)
         .frame(maxWidth: .infinity)

--- a/MongleFeatures/Sources/MongleFeatures/Presentation/V2/V2MongleCharacter.swift
+++ b/MongleFeatures/Sources/MongleFeatures/Presentation/V2/V2MongleCharacter.swift
@@ -27,7 +27,11 @@ struct V2Mongle<Decoration: View>: View {
     var backDecorationId: String? = nil
     /// 발밑(feet) 슬롯 장식 id. 본체 하단에 깐다.
     var feetDecorationId: String? = nil
-    /// 머리(head) 슬롯 장식 — 본체 앞에 얹는 closure (기존 호출부 호환).
+    /// 머리계열(head/aboveHead/hand) 장식 id. 있으면 placement 기반으로 렌더하고
+    /// 아래 `decoration` 클로저 대신 쓴다. id→뷰는 DecorationCatalog.headView 공유.
+    var headDecorationId: String? = nil
+    /// 머리(head) 슬롯 장식 — 본체 앞에 얹는 closure (레거시/정적 호출부 호환).
+    /// headDecorationId 가 nil 일 때만 이 클로저 경로가 -size*0.28 로 렌더된다.
     var decoration: () -> Decoration
 
     private var resolvedEye: CGFloat { eyeSize ?? size * 0.18 }
@@ -115,13 +119,37 @@ struct V2Mongle<Decoration: View>: View {
                     .allowsHitTesting(false)
             }
 
-            // head decoration — drawn last so it sits in front of the body
-            decoration()
-                .frame(width: containerW, alignment: .center)
-                .offset(y: -size * 0.28)
-                .allowsHitTesting(false)
+            // head 계열 decoration — drawn last so it sits in front of the body.
+            // headDecorationId 가 있으면 placement(anchor) 기반으로 위치/스케일을 정하고,
+            // 없으면 레거시 클로저를 기존 -size*0.28 로 렌더한다(정적 호출부 호환).
+            if let headDecorationId {
+                let placement = DecorationCatalog.placement(for: headDecorationId)
+                let base = headBaseline(placement.anchor)
+                DecorationCatalog.headView(for: headDecorationId)
+                    .scaleEffect(placement.scale)
+                    .frame(width: containerW, alignment: .center)
+                    .offset(x: base.width + placement.offset.width * size,
+                            y: base.height + placement.offset.height * size)
+                    .allowsHitTesting(false)
+            } else {
+                decoration()
+                    .frame(width: containerW, alignment: .center)
+                    .offset(y: -size * 0.28)
+                    .allowsHitTesting(false)
+            }
         }
         .frame(width: containerW, height: containerH, alignment: .topLeading)
+    }
+
+    /// 앵커별 head 계열 baseline 오프셋 (size 비례, V2Mongle 좌표 원점 기준).
+    private func headBaseline(_ anchor: DecorationAnchor) -> CGSize {
+        switch anchor {
+        case .onHead:    return CGSize(width: 0, height: -size * 0.28)   // 현행
+        case .aboveHead: return CGSize(width: 0, height: -size * 0.40)   // 머리 위로 살짝 띄움(onHead -0.28 대비)
+        case .hand:      return CGSize(width: size * 0.40, height: size * 0.30) // 측면·하단 손
+        // back/feet 가 head 경로로 들어올 일은 없지만 안전 기본(현행 onHead).
+        case .back, .feet: return CGSize(width: 0, height: -size * 0.28)
+        }
     }
 
     private var eye: some View {
@@ -147,7 +175,8 @@ extension V2Mongle where Decoration == EmptyView {
         ringColor: Color? = nil,
         shadow: Bool = true,
         backDecorationId: String? = nil,
-        feetDecorationId: String? = nil
+        feetDecorationId: String? = nil,
+        headDecorationId: String? = nil
     ) {
         self.color = color
         self.name = name
@@ -162,6 +191,7 @@ extension V2Mongle where Decoration == EmptyView {
         self.shadow = shadow
         self.backDecorationId = backDecorationId
         self.feetDecorationId = feetDecorationId
+        self.headDecorationId = headDecorationId
         self.decoration = { EmptyView() }
     }
 }

--- a/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/en.lproj/Localizable.strings
@@ -14,6 +14,7 @@
 "shop_tab_background" = "Background";
 "shop_tab_decoration" = "Decorate";
 "shop_slot_head" = "Head";
+"shop_slot_hand" = "Hand";
 "shop_slot_back" = "Back";
 "shop_slot_feet" = "Feet";
 "shop_slot_hint" = "Switch between head, back, and feet to decorate";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ja.lproj/Localizable.strings
@@ -14,6 +14,7 @@
 "shop_tab_background" = "背景";
 "shop_tab_decoration" = "かざり";
 "shop_slot_head" = "あたま";
+"shop_slot_hand" = "手";
 "shop_slot_back" = "せなか";
 "shop_slot_feet" = "あしもと";
 "shop_slot_hint" = "あたま・せなか・あしもとを切り替えて飾ろう";

--- a/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
+++ b/MongleFeatures/Sources/MongleFeatures/Resources/ko.lproj/Localizable.strings
@@ -14,6 +14,7 @@
 "shop_tab_background" = "배경";
 "shop_tab_decoration" = "꾸미기";
 "shop_slot_head" = "머리";
+"shop_slot_hand" = "손";
 "shop_slot_back" = "등";
 "shop_slot_feet" = "발밑";
 "shop_slot_hint" = "머리·등·발밑을 바꿔가며 꾸며보세요";


### PR DESCRIPTION
> ⚠️ Base = `fix/shop-deco-none-tile` (#140) 위 **스택 PR**. #140 머지 후 base를 main으로 retarget 예정.

## 2단계 — 장식 부착위치 세밀화 + 손 슬롯
계획 근거: `Documents/deco-placement/`, 메모리 `project_mongle_shop_feature` 2단계.

### A. Placement 세밀화 (클라 전용, 시각 개선)
- `DecorationAnchor`(onHead/aboveHead/hand/back/feet) + `DecorationPlacement(anchor,offset,scale)` + `DecorationCatalog.placement(for:)`. anchor 분류는 카탈로그 단일소스.
- `V2Mongle`(상점)·`MongleView`(홈) 두 렌더 레이어를 anchor 기반으로 통일. 좌표 원점이 달라 baseline은 레이어별, 분류는 공유. `headDecorationId` 경로 추가 — 레거시 closure 호출부는 그대로 호환.
- 호출부 3곳(ShopView.preview / ShopDetailView.decoratedMongle / MainTabView) anchor 분기.
- 분류: 화관/리본/산타=onHead, **후광=aboveHead(머리 위 띄움)**, **풍선=hand(측면·하단)**, 날개/망토=back, 운동화/구름=feet.

### B. 손(hand) 브라우징 슬롯
- `DecorationSlot += hand` (선언순 head,hand,back,feet → 세그먼트 머리/손/등/발밑).
- 풍선 slot head→hand(`handItems` 신설). slotTitle/shopSlotTitle/items(for:)/ShopMapper.slot(from:) hand 케이스. L10n `shop_slot_hand` ko/en/ja.
- 착용은 여전히 전역 단일 1개(슬롯=브라우징/분류용).

## 서버 (별도 PR)
`Mongle-Server`: `DecorationSlot` 유니온 += 'hand', 풍선 카탈로그 slot 'head'→'hand'. db push 불필요(카탈로그 상수). → 별도 PR.

## ⚠️ 배포 동시성 (중요)
풍선 slot이 iOS↔서버 양쪽 'hand'. **서버만 먼저 배포 + iOS 구버전이면 구버전 `slot(from:)`에 hand 케이스가 없어 풍선이 모든 세그먼트에서 사라짐.** → **iOS 신버전을 서버보다 먼저 또는 동시 배포.** 서버 배포는 `npm run build` 경유(tsoa routes 재생성).

## 검증
- 전체 앱 **BUILD SUCCEEDED** (iPhone 17 Pro).
- QA 에이전트 4회(라운드별 2): iOS 회귀/서버 계약 검토 — 치명 0건. (Round1에서 상세 130pt 미리보기 주석처리 회귀 1건 발견·복원.)
- ImageRenderer 스냅샷 육안 검증: 상점96·홈56·상세130 — 후광 띄움 ✓, 풍선 손 위치 ✓, 화관/리본 머리 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)